### PR TITLE
Histogram Errors

### DIFF
--- a/nbody/include/nbody_types.h
+++ b/nbody/include/nbody_types.h
@@ -338,8 +338,8 @@ typedef struct
     unsigned int totalSimulated;
     int hasRawCounts;
     HistogramParams params;
+		double massPerParticle;
     HistData data[1];
-    double massPerParticle;
 } NBodyHistogram;
 
 


### PR DESCRIPTION
Edited NbHistogram struct in nbody_types.h to fix errors in the creation of histograms

Somewhat temporary fix, will work but not exactly the best way to do it.  If somebody else adds another parameter in the future the same error will happen again.   

I'll change it to separately allocate an array for the histData when I get the chance.
