### PR TITLE
Mendel iterswitch

### DIFF
--- a/nbody/include/nbody_defaults.h
+++ b/nbody/include/nbody_defaults.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define DEFAULT_BEST_LIKELIHOOD_START ((real) 0.95)
 #define DEFAULT_SIGMA_CUTOFF ((real) 2.5)
-/*#define DEFAULT_SIGMA_ITER ((unsinged int) 6)*/
+#define DEFAULT_SIGMA_ITER ((real) 6)
 #define DEFAULT_DISP_CORRECTION ((real) 1.111)
 
 #define DEFAULT_NOT_USE ((real) -1)

--- a/nbody/include/nbody_defaults.h
+++ b/nbody/include/nbody_defaults.h
@@ -50,6 +50,7 @@ extern "C" {
 
 #define DEFAULT_BEST_LIKELIHOOD_START ((real) 0.95)
 #define DEFAULT_SIGMA_CUTOFF ((real) 2.5)
+/*#define DEFAULT_SIGMA_ITER ((unsinged int) 6)*/
 #define DEFAULT_DISP_CORRECTION ((real) 1.111)
 
 #define DEFAULT_NOT_USE ((real) -1)

--- a/nbody/include/nbody_types.h
+++ b/nbody/include/nbody_types.h
@@ -432,7 +432,7 @@ typedef struct MW_ALIGN_TYPE
     
     real BetaSigma;           /* sigma cutoff for the outlier rejection for the bin beta dispersions */ 
     real VelSigma;            /* sigma cutoff for the outlier rejection for the bin vel dispersions */ 
-    /*real IterMax;*/             /* number of times to apply outlier rejection with sigma cutoff */ 
+    real IterMax;             /* number of times to apply outlier rejection with sigma cutoff */ 
     real BetaCorrect;         /* correction factor for correcting the distribution after outlier rejection */
     real VelCorrect;          /* correction factor for correcting the distribution after outlier rejection */
     
@@ -447,7 +447,7 @@ typedef struct MW_ALIGN_TYPE
 #define EMPTY_NBODYCTX { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,                               \
                          InvalidCriterion, EXTERNAL_POTENTIAL_DEFAULT,               \
                          FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,     \
-                         0, 0, 0, 0, 0, 0, 0, 0, 0,/* 0,*/                               \
+                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                               \
                          EMPTY_POTENTIAL }
 
 /* Negative codes can be nonfatal but useful return statuses.

--- a/nbody/include/nbody_types.h
+++ b/nbody/include/nbody_types.h
@@ -432,6 +432,7 @@ typedef struct MW_ALIGN_TYPE
     
     real BetaSigma;           /* sigma cutoff for the outlier rejection for the bin beta dispersions */ 
     real VelSigma;            /* sigma cutoff for the outlier rejection for the bin vel dispersions */ 
+    /*real IterMax;*/             /* number of times to apply outlier rejection with sigma cutoff */ 
     real BetaCorrect;         /* correction factor for correcting the distribution after outlier rejection */
     real VelCorrect;          /* correction factor for correcting the distribution after outlier rejection */
     
@@ -446,7 +447,7 @@ typedef struct MW_ALIGN_TYPE
 #define EMPTY_NBODYCTX { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,                               \
                          InvalidCriterion, EXTERNAL_POTENTIAL_DEFAULT,               \
                          FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,     \
-                         0, 0, 0, 0, 0, 0, 0, 0, 0,                                  \
+                         0, 0, 0, 0, 0, 0, 0, 0, 0,/* 0,*/                               \
                          EMPTY_POTENTIAL }
 
 /* Negative codes can be nonfatal but useful return statuses.

--- a/nbody/sample_workunits/EMD_v168.lua
+++ b/nbody/sample_workunits/EMD_v168.lua
@@ -95,7 +95,7 @@ function makeContext()
       useBetaDisp   = use_beta_disps,
       BetaSigma     = SigmaCutoff,
       VelSigma      = SigmaCutoff,
-      --IterMax       = SigmaIter,
+      IterMax       = SigmaIter,
       BetaCorrect   = Correction,
       VelCorrect    = Correction,
       theta       = 1.0

--- a/nbody/sample_workunits/EMD_v168.lua
+++ b/nbody/sample_workunits/EMD_v168.lua
@@ -25,6 +25,7 @@ bta_lower_range = -15     -- lower range for beta
 bta_upper_range = 15      -- upper range for beta
         
 SigmaCutoff          = 2.5     -- -- sigma cutoff for outlier rejection DO NOT CHANGE -- --
+SigmaIter            = 6       -- -- number of times to apply outlier rejection DO NOT CHANGE -- --
 Correction           = 1.111   -- -- correction for outlier rejection   DO NOT CHANGE -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 
@@ -94,6 +95,7 @@ function makeContext()
       useBetaDisp   = use_beta_disps,
       BetaSigma     = SigmaCutoff,
       VelSigma      = SigmaCutoff,
+      --IterMax       = SigmaIter,
       BetaCorrect   = Correction,
       VelCorrect    = Correction,
       theta       = 1.0

--- a/nbody/sample_workunits/for_developers.lua
+++ b/nbody/sample_workunits/for_developers.lua
@@ -142,7 +142,7 @@ function makeContext()
       Ntsteps       = Ntime_steps,
       BetaSigma     = SigmaCutoff,
       VelSigma      = SigmaCutoff,
-      --IterMax       = SigmaIter,
+      IterMax       = SigmaIter,
       BetaCorrect   = Correction,
       VelCorrect    = Correction,
       MultiOutput   = useMultiOutputs,

--- a/nbody/sample_workunits/for_developers.lua
+++ b/nbody/sample_workunits/for_developers.lua
@@ -42,6 +42,7 @@ bta_lower_range = -15     -- lower range for beta
 bta_upper_range = 15      -- upper range for beta
 
 SigmaCutoff          = 2.5     -- -- sigma cutoff for outlier rejection DO NOT CHANGE -- --
+SigmaIter            = 6       -- -- number of times to apply outlier rejection DO NOT CHANGE -- --
 Correction           = 1.111   -- -- correction for outlier rejection   DO NOT CHANGE -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 
@@ -141,6 +142,7 @@ function makeContext()
       Ntsteps       = Ntime_steps,
       BetaSigma     = SigmaCutoff,
       VelSigma      = SigmaCutoff,
+      --IterMax       = SigmaIter,
       BetaCorrect   = Correction,
       VelCorrect    = Correction,
       MultiOutput   = useMultiOutputs,

--- a/nbody/src/nbody_defaults.c
+++ b/nbody/src/nbody_defaults.c
@@ -43,7 +43,7 @@ const NBodyCtx defaultNBodyCtx =
     
     /* .BetaSigma       */  DEFAULT_SIGMA_CUTOFF,
     /* .VelSigma        */  DEFAULT_SIGMA_CUTOFF,
-    /* .IterMax         */  /*DEFAULT_SIGMA_ITER,*/
+    /* .IterMax         */  DEFAULT_SIGMA_ITER,
     /* .BetaCorrect     */  DEFAULT_DISP_CORRECTION,
     /* .VelCorrect      */  DEFAULT_DISP_CORRECTION,
        

--- a/nbody/src/nbody_defaults.c
+++ b/nbody/src/nbody_defaults.c
@@ -43,6 +43,7 @@ const NBodyCtx defaultNBodyCtx =
     
     /* .BetaSigma       */  DEFAULT_SIGMA_CUTOFF,
     /* .VelSigma        */  DEFAULT_SIGMA_CUTOFF,
+    /* .IterMax         */  /*DEFAULT_SIGMA_ITER,*/
     /* .BetaCorrect     */  DEFAULT_DISP_CORRECTION,
     /* .VelCorrect      */  DEFAULT_DISP_CORRECTION,
        

--- a/nbody/src/nbody_histogram.c
+++ b/nbody/src/nbody_histogram.c
@@ -107,7 +107,7 @@ static void nbPrintHistogramHeader(FILE* f,
                                    const NBodyCtx* ctx,
                                    const HistogramParams* hp,
                                    int nbody,
-                                   float bestLikelihood_time)
+                                   real bestLikelihood_time)
 {
     char tBuf[256];
     const Potential* p = &ctx->pot;

--- a/nbody/src/nbody_histogram.c
+++ b/nbody/src/nbody_histogram.c
@@ -106,7 +106,8 @@ unsigned int nbCorrectTotalNumberInHistogram(const NBodyHistogram* histogram, /*
 static void nbPrintHistogramHeader(FILE* f,
                                    const NBodyCtx* ctx,
                                    const HistogramParams* hp,
-                                   int nbody)
+                                   int nbody,
+                                   float bestLikelihood_time)
 {
     char tBuf[256];
     const Potential* p = &ctx->pot;
@@ -133,7 +134,8 @@ static void nbPrintHistogramHeader(FILE* f,
     
     fprintf(f,
             "# Nbody = %d\n"
-            "# Evolve time = %f\n"
+            "# Evolve backward time = %f\n"
+            "# Evolve forward time = %f\n"
             "# Timestep = %f\n"
             "# Sun GC Dist = %f\n"
             "# Criterion = %s\n"
@@ -143,6 +145,7 @@ static void nbPrintHistogramHeader(FILE* f,
             "#\n",
             nbody,
             ctx->timeEvolve,
+            bestLikelihood_time,
             ctx->timestep,
             ctx->sunGCDist,
             showCriterionT(ctx->criterion),
@@ -320,7 +323,7 @@ void nbWriteHistogram(const char* histoutFileName,
         }
     }
 
-    nbPrintHistogramHeader(f, ctx, &histogram->params, st->nbody);
+    nbPrintHistogramHeader(f, ctx, &histogram->params, st->nbody, st->bestLikelihood_time);
     nbPrintHistogram(f, histogram);
 
     if (f != DEFAULT_OUTPUT_FILE)

--- a/nbody/src/nbody_histogram.c
+++ b/nbody/src/nbody_histogram.c
@@ -399,7 +399,8 @@ NBodyHistogram* nbCreateHistogram(const NBodyCtx* ctx,        /* Simulation cont
     real betaStart = hp->betaStart;
     unsigned int lambdaBins = hp->lambdaBins;
     unsigned int betaBins = hp->betaBins;
-    unsigned int IterMax = 6;
+    unsigned int IterMax = ctx->IterMax;
+    /*unsigned int IterMax = 6;*/	/*Default value for IterMax*/
     unsigned int nBin = lambdaBins * betaBins;
     unsigned int body_count = 0;
     unsigned int ub_counter = 0;

--- a/nbody/src/nbody_histogram.c
+++ b/nbody/src/nbody_histogram.c
@@ -399,6 +399,7 @@ NBodyHistogram* nbCreateHistogram(const NBodyCtx* ctx,        /* Simulation cont
     real betaStart = hp->betaStart;
     unsigned int lambdaBins = hp->lambdaBins;
     unsigned int betaBins = hp->betaBins;
+    unsigned int IterMax = 6;
     unsigned int nBin = lambdaBins * betaBins;
     unsigned int body_count = 0;
     unsigned int ub_counter = 0;
@@ -505,7 +506,7 @@ NBodyHistogram* nbCreateHistogram(const NBodyCtx* ctx,        /* Simulation cont
     nbCalcVelDisp(histogram, TRUE, ctx->VelCorrect);
     nbCalcBetaDisp(histogram, TRUE, ctx->BetaCorrect);
     /* this converges somewhere between 3 and 6 iterations */
-    for(int i = 0; i < 6; i++)
+    for(int i = 0; i < IterMax; i++)
     {
         nbRemoveBetaOutliers(st, histogram, use_betabody, betas, ctx->BetaSigma);
         nbCalcBetaDisp(histogram, FALSE, ctx->BetaCorrect);

--- a/nbody/src/nbody_lua_types/nbody_lua_nbodyctx.c
+++ b/nbody/src/nbody_lua_types/nbody_lua_nbodyctx.c
@@ -106,7 +106,7 @@ static int createNBodyCtx(lua_State* luaSt)
             { "OutputFreq",    LUA_TNUMBER,  NULL, FALSE, &ctx.OutputFreq    },
             { "BetaSigma",     LUA_TNUMBER,  NULL, TRUE,  &ctx.BetaSigma     },
             { "VelSigma",      LUA_TNUMBER,  NULL, TRUE,  &ctx.VelSigma      },
-            /*{ "IterMax",       LUA_TNUMBER,  NULL, TRUE,  &ctx.IterMax       },*/
+            { "IterMax",       LUA_TNUMBER,  NULL, TRUE,  &ctx.IterMax       },
             { "BetaCorrect",   LUA_TNUMBER,  NULL, TRUE,  &ctx.BetaCorrect   },
             { "VelCorrect",    LUA_TNUMBER,  NULL, TRUE,  &ctx.VelCorrect    },
             END_MW_NAMED_ARG
@@ -243,7 +243,7 @@ static const Xet_reg_pre gettersNBodyCtx[] =
     { "OutputFreq",      getNumber,     offsetof(NBodyCtx, OutputFreq)  },
     { "BetaSigma",       getNumber,     offsetof(NBodyCtx, BetaSigma)   },
     { "VelSigma",        getNumber,     offsetof(NBodyCtx, VelSigma)    },
-    /*{ "IterMax",         getNumber,     offsetof(NBodyCtx, IterMax)     },*/
+    { "IterMax",         getNumber,     offsetof(NBodyCtx, IterMax)     },
     { "BetaCorrect",     getNumber,     offsetof(NBodyCtx, BetaCorrect) },
     { "VelCorrect",      getNumber,     offsetof(NBodyCtx, VelCorrect)  },
     { NULL, NULL, 0 }
@@ -271,7 +271,7 @@ static const Xet_reg_pre settersNBodyCtx[] =
     { "OutputFreq",      setNumber,     offsetof(NBodyCtx, OutputFreq)  },
     { "BetaSigma",       setNumber,     offsetof(NBodyCtx, BetaSigma)   },
     { "VelSigma",        setNumber,     offsetof(NBodyCtx, VelSigma)    },
-    /*{ "Itermax",         setNumber,     offsetof(NBodyCtx, IterMax)    },*/
+    { "IterMax",         setNumber,     offsetof(NBodyCtx, IterMax)    },
     { "BetaCorrect",     setNumber,     offsetof(NBodyCtx, BetaCorrect) },
     { "VelCorrect",      setNumber,     offsetof(NBodyCtx, VelCorrect)  },
     { NULL, NULL, 0 }

--- a/nbody/src/nbody_lua_types/nbody_lua_nbodyctx.c
+++ b/nbody/src/nbody_lua_types/nbody_lua_nbodyctx.c
@@ -106,6 +106,7 @@ static int createNBodyCtx(lua_State* luaSt)
             { "OutputFreq",    LUA_TNUMBER,  NULL, FALSE, &ctx.OutputFreq    },
             { "BetaSigma",     LUA_TNUMBER,  NULL, TRUE,  &ctx.BetaSigma     },
             { "VelSigma",      LUA_TNUMBER,  NULL, TRUE,  &ctx.VelSigma      },
+            /*{ "IterMax",       LUA_TNUMBER,  NULL, TRUE,  &ctx.IterMax       },*/
             { "BetaCorrect",   LUA_TNUMBER,  NULL, TRUE,  &ctx.BetaCorrect   },
             { "VelCorrect",    LUA_TNUMBER,  NULL, TRUE,  &ctx.VelCorrect    },
             END_MW_NAMED_ARG
@@ -242,6 +243,7 @@ static const Xet_reg_pre gettersNBodyCtx[] =
     { "OutputFreq",      getNumber,     offsetof(NBodyCtx, OutputFreq)  },
     { "BetaSigma",       getNumber,     offsetof(NBodyCtx, BetaSigma)   },
     { "VelSigma",        getNumber,     offsetof(NBodyCtx, VelSigma)    },
+    /*{ "IterMax",         getNumber,     offsetof(NBodyCtx, IterMax)     },*/
     { "BetaCorrect",     getNumber,     offsetof(NBodyCtx, BetaCorrect) },
     { "VelCorrect",      getNumber,     offsetof(NBodyCtx, VelCorrect)  },
     { NULL, NULL, 0 }
@@ -269,6 +271,7 @@ static const Xet_reg_pre settersNBodyCtx[] =
     { "OutputFreq",      setNumber,     offsetof(NBodyCtx, OutputFreq)  },
     { "BetaSigma",       setNumber,     offsetof(NBodyCtx, BetaSigma)   },
     { "VelSigma",        setNumber,     offsetof(NBodyCtx, VelSigma)    },
+    /*{ "Itermax",         setNumber,     offsetof(NBodyCtx, IterMax)    },*/
     { "BetaCorrect",     setNumber,     offsetof(NBodyCtx, BetaCorrect) },
     { "VelCorrect",      setNumber,     offsetof(NBodyCtx, VelCorrect)  },
     { NULL, NULL, 0 }

--- a/nbody/src/nbody_types.c
+++ b/nbody/src/nbody_types.c
@@ -614,7 +614,7 @@ int equalNBodyCtx(const NBodyCtx* ctx1, const NBodyCtx* ctx2)
         && feqWithNan(ctx1->OutputFreq, ctx2->OutputFreq)
         && feqWithNan(ctx1->BetaSigma, ctx2->BetaSigma)
         && feqWithNan(ctx1->VelSigma, ctx2->VelSigma)
-        /*&& feqWithNan(ctx1->IterMax, ctx2->Itermax)*/
+        && feqWithNan(ctx1->IterMax, ctx2->IterMax)
         && feqWithNan(ctx1->BetaCorrect, ctx2->BetaCorrect)
         && feqWithNan(ctx1->VelCorrect, ctx2->VelCorrect)
         && feqWithNan(ctx1->quietErrors, ctx2->quietErrors)

--- a/nbody/src/nbody_types.c
+++ b/nbody/src/nbody_types.c
@@ -614,6 +614,7 @@ int equalNBodyCtx(const NBodyCtx* ctx1, const NBodyCtx* ctx2)
         && feqWithNan(ctx1->OutputFreq, ctx2->OutputFreq)
         && feqWithNan(ctx1->BetaSigma, ctx2->BetaSigma)
         && feqWithNan(ctx1->VelSigma, ctx2->VelSigma)
+        /*&& feqWithNan(ctx1->IterMax, ctx2->Itermax)*/
         && feqWithNan(ctx1->BetaCorrect, ctx2->BetaCorrect)
         && feqWithNan(ctx1->VelCorrect, ctx2->VelCorrect)
         && feqWithNan(ctx1->quietErrors, ctx2->quietErrors)


### PR DESCRIPTION
These changes allow developers to change the numbers of times to apply the sigma cutoff from the LUA file, as well as printing the best likelihood forward time into the histogram file.