### PR TITLE
Print kernel compile log and flags.

### DIFF
--- a/milkyway/src/milkyway_cl_program.c
+++ b/milkyway/src/milkyway_cl_program.c
@@ -100,6 +100,21 @@ cl_int mwBuildProgram(cl_program program, cl_device_id device, const char* optio
     if (err != CL_SUCCESS)
     {
         mwPerrorCL(err, "clBuildProgram: Build failure");
+
+        if (err == CL_BUILD_PROGRAM_FAILURE) {
+            char* buildLog = mwGetBuildLog(program, device);
+            if (buildLog && strcmp(buildLog, ""))
+            {
+                mw_printf("Build log:\n"
+                          "--------------------------------------------------------------------------------\n"
+                          "%s\n"
+                          "--------------------------------------------------------------------------------\n",
+                          buildLog
+                    );
+            }
+            free(buildLog);
+        }
+
     }
 
     return err;

--- a/nbody/src/nbody_cl.c
+++ b/nbody/src/nbody_cl.c
@@ -727,6 +727,7 @@ cl_bool nbLoadKernels(const NBodyCtx* ctx, NBodyState* st)
 
     compileFlags = nbGetCompileFlags(ctx, st, &ci->di);
     assert(compileFlags);
+    mw_printf("Kernel Compile Flags: %s\n",compileFlags);
 
     program = mwCreateProgramFromSrc(ci, 1, &src, &srcLen, compileFlags);
     free(compileFlags);


### PR DESCRIPTION
The callback, that is supposed to print it, is not called on my system.