### PR TITLE
Fix broken logic while creating kernels

### DIFF
--- a/nbody/src/nbody_cl.c
+++ b/nbody/src/nbody_cl.c
@@ -736,12 +736,12 @@ cl_bool nbLoadKernels(const NBodyCtx* ctx, NBodyState* st)
         return CL_TRUE;
     }
 
-    if (!nbCreateKernels(program, st->kernels))
-        return CL_TRUE;
+    if (nbCreateKernels(program, st->kernels))
+        return CL_FALSE;
 
     clReleaseProgram(program);
 
-    return CL_FALSE;
+    return CL_TRUE;
 }
 
 /* Return CL_FALSE if device isn't capable of running this */


### PR DESCRIPTION
The function was confusing true and false as a return code to indicate failure and success.

However the app still crashes, because the kernel is missing some flags.