### PR TITLE
Attempt to make NBody work

### DIFF
--- a/nbody/src/nbody_cl.c
+++ b/nbody/src/nbody_cl.c
@@ -576,7 +576,7 @@ static char* nbGetCompileFlags(const NBodyCtx* ctx, const NBodyState* st, const 
                  "-DTHETA=%a "
                  "-DUSE_QUAD=%d "
 
-                 "-DNEWCRITERION=%d "
+                 "-DTREECODE=%d "
                  "-DSW93=%d "
                  "-DBH86=%d "
                  "-DEXACT=%d "

--- a/nbody/src/nbody_cl.c
+++ b/nbody/src/nbody_cl.c
@@ -1291,7 +1291,7 @@ static cl_int nbExecuteTreeConstruction(NBodyState* st)
 
             ++buildIterations;
         }
-        while (treeStatus.doneCnt != st->effNBody);
+        while (treeStatus.doneCnt < st->effNBody);
     }
 
     /* FIXME: Work sizes */


### PR DESCRIPTION
Kernel was expecting `TREECODE`, but the driving code was supplying `NEWCRITERION` flag.
Then the app was stalling at 20001 of 20000 bodies processed, so I change the loop exit condition.
However the app still crashes. (Follow up to #64 ) It almost looks as if the currently published app was not compiled from this code, but some other.