### PR TITLE
Add support for Hawaii GPUs

### DIFF
--- a/milkyway/include/milkyway_cl_types.h
+++ b/milkyway/include/milkyway_cl_types.h
@@ -77,7 +77,9 @@ typedef enum MWCALtargetEnum {
 
     MW_CAL_TARGET_TAHITI    = 20,
     MW_CAL_TARGET_THAMES    = 21,
-    MW_CAL_TARGET_LOMBOK    = 22
+    MW_CAL_TARGET_LOMBOK    = 22,
+
+    MW_CAL_TARGET_HAWAII    = 23
 } MWCALtargetEnum;
 
 typedef struct

--- a/milkyway/src/milkyway_cl_device.c
+++ b/milkyway/src/milkyway_cl_device.c
@@ -77,6 +77,10 @@ static const AMDGPUData amdGPUData[] =
     { "Thames",     MW_CAL_TARGET_THAMES,   16 * 4, 4, 64 },
     { "Lombok",     MW_CAL_TARGET_LOMBOK,   16 * 4, 4, 64 },
 
+    /* Sea Islands family W8100, W9100, S9150 */
+    { "Hawaii",     MW_CAL_TARGET_HAWAII,   16 * 4, 2, 64 },
+
+
 #if 0
     /* These are there, but I don't know about them */
     { "WinterPark",                        16 * 5, 0, 64 },

--- a/milkyway/src/milkyway_cl_show_types.c
+++ b/milkyway/src/milkyway_cl_show_types.c
@@ -401,6 +401,9 @@ const char* showMWCALtargetEnum(const MWCALtargetEnum x)
         case MW_CAL_TARGET_LOMBOK:
             return "MW_CAL_TARGET_LOMBOK";
 
+        case MW_CAL_TARGET_HAWAII:
+            return "MW_CAL_TARGET_HAWAII";
+
         default:
             return "Invalid MWCALtargetEnum";
     }


### PR DESCRIPTION
Hawaii GPUs such as W8100, W9100, and S9150 have 1/2 ratio DP compute to SP.

Reference: The patch is based on the discussion on "AMD FirePro S9150"
[thread][0] with suggestion by user "BeemerBiker".

[0]: http://milkyway.cs.rpi.edu/milkyway/forum_thread.php?id=4268

Signed-off-by: Tuan T. Pham <tuan@vt.edu>

CC: @beemerbiker, @weissj3 