### PR TITLE
Update package name for Ubuntu 14.04 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
       - g++-multilib
       - libssl-dev
       - opencl-headers
-      - opencl-dev
+      - ocl-icd-opencl-dev
       - libreadline-dev
       - libgmp-dev
       - libmpfr-dev


### PR DESCRIPTION
.travis.yml:
    * `ocl-icd-opencl-dev` provides opencl-dev now

Signed-off-by: Tuan T. Pham <tuan@vt.edu>