### PR TITLE
[Draft] Emscripten build support

### DIFF
--- a/crlibm/crlibm_private.c
+++ b/crlibm/crlibm_private.c
@@ -65,7 +65,7 @@
 
 /* An init function which sets FPU flags when needed */
 unsigned long long crlibm_init() {
-#ifndef CRLIBM_TYPEOS_BSD
+#if !defined(CRLIBM_TYPEOS_BSD) && !defined(__EMSCRIPTEN__)
 #if defined(CRLIBM_HAS_FPU_CONTROL) && (defined(CRLIBM_TYPECPU_X86) || defined(CRLIBM_TYPECPU_AMD64))
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
@@ -124,7 +124,7 @@ unsigned long long crlibm_init() {
 
 /* An exit function which sets FPU flags to initial value */
 void crlibm_exit(unsigned long long int oldcw) {
-#ifndef CRLIBM_TYPEOS_BSD
+#if !defined(CRLIBM_TYPEOS_BSD) && !defined(__EMSCRIPTEN__)
 #if (defined(CRLIBM_TYPECPU_X86) || defined(CRLIBM_TYPECPU_AMD64))
 
 #ifndef _MSC_VER

--- a/crlibm/crlibm_private.h
+++ b/crlibm/crlibm_private.h
@@ -22,7 +22,7 @@
 
 
 
-#if (defined(CRLIBM_TYPECPU_X86) || defined(CRLIBM_TYPECPU_AMD64))
+#if ( defined(CRLIBM_TYPECPU_X86) || defined(CRLIBM_TYPECPU_AMD64) ) && !defined(__EMSCRIPTEN__)
 #  ifdef HAVE_FPU_CONTROL_H
 #    include <fpu_control.h>
 #  endif

--- a/dSFMT/CMakeLists.txt
+++ b/dSFMT/CMakeLists.txt
@@ -33,7 +33,7 @@ set(DSFMT_MEXP "19937" CACHE STRING "dSFMT mexp")
 mark_as_advanced(DSFMT_MMEXP)
 
 if(NOT MSVC)
-  set(dsmft_flags "-O3 -DNDEBUG -finline-functions -fno-strict-aliasing --param max-inline-insns-single=1800 -std=c99 ${SSE2_FLAGS}")
+  set(dsmft_flags "-O3 -DNDEBUG -finline-functions -fno-strict-aliasing --param=max-inline-insns-single=1800 -std=c99 ${SSE2_FLAGS}")
 else()
   set(dsmft_flags "${SSE2_FLAGS}")
 endif()

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -32,7 +32,10 @@ set( LUA_CPATH "LUA_CPATH" CACHE INTERNAL "Environment variable to use as packag
 set( LUA_INIT "LUA_INIT" CACHE INTERNAL "Environment variable for initial script." )
 
 #option( LUA_ANSI "Use only ansi features." OFF )
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 option( LUA_USE_RELATIVE_LOADLIB "Use modified loadlib.c with support for relative paths on posix systems." ON)
+endif()
 mark_as_advanced(LUA_USE_RELATIVE_LOADLIB)
 
 set( LUA_IDSIZE 60 CACHE INTERNAL "gives the maximum size for the description of the source." )
@@ -69,6 +72,13 @@ if( WIN32 AND NOT CYGWIN )
   string( REPLACE "/" ${LUA_DIRSEP} LUA_CDIR "${LUA_CDIR}" )
   string( REPLACE "/" ${LUA_DIRSEP} LUA_PATH_DEFAULT "${LUA_PATH_DEFAULT}" )
   string( REPLACE "/" ${LUA_DIRSEP} LUA_CPATH_DEFAULT "${LUA_CPATH_DEFAULT}" )
+elseif( CMAKE_SYSTEM_NAME STREQUAL "Emscripten" )
+  # Emscripten
+  option( LUA_USE_POSIX "Use POSIX functionality." OFF )
+  option( LUA_USE_DLOPEN "Use dynamic linker to load modules." OFF)
+  option( LUA_USE_ISATTY "Use tty." OFF )
+  option( LUA_USE_POPEN "Use popen." OFF )
+  option( LUA_USE_ULONGJMP "Use ulongjmp" OFF)
 else()
   # Posix systems (incl. Cygwin)
   option( LUA_USE_POSIX "Use POSIX functionality." ON )

--- a/milkyway/include/milkyway_config.h.in
+++ b/milkyway/include/milkyway_config.h.in
@@ -160,6 +160,8 @@
   #define ARCH_STRING "MIPS64"
 #elif defined(__mips)
   #define ARCH_STRING "MIPS"
+#elif defined(__wasm__)
+  #define ARCH_STRING "WASM"
 #else
   #define ARCH_STRING "Unknown architecture"
   #warning "Unknown architecture!"

--- a/milkyway/include/milkyway_extra.h
+++ b/milkyway/include/milkyway_extra.h
@@ -79,7 +79,7 @@ typedef char mwbool;
   #define LLU "%I64u"
 #else
   #define ZU "%zu"
-  #define LLU "%"PRIu64
+  #define LLU "%" PRIu64
 #endif /* _WIN32 */
 
 #endif /* _MILKYWAY_EXTRA_H_ */

--- a/milkyway/include/milkyway_math_double.h
+++ b/milkyway/include/milkyway_math_double.h
@@ -113,7 +113,7 @@ typedef MW_ALIGN_TYPE_V(32) double double4[4];
 #define mw_fmod fmod
 
 /* CHECKME: mw_fract */
-#define mw_fract(x) mw_fmin((x) – mw_floor(x), 0x1.fffffep-1f)
+#define mw_fract(x) mw_fmin((x) - mw_floor(x), 0x1.fffffep-1f)
 
 #define mw_frexp frexp
 #define mw_hypot(x, y) mw_sqrt(sqr(x) + sqr(y))

--- a/nbody/src/nbody_lua_types/nbody_lua_spherical.c
+++ b/nbody/src/nbody_lua_types/nbody_lua_spherical.c
@@ -24,6 +24,7 @@ along with Milkyway@Home.  If not, see <http://www.gnu.org/licenses/>.
 #include "nbody_types.h"
 #include "nbody_show.h"
 #include "nbody_lua_spherical.h"
+#include "nbody_check_params.h"
 #include "milkyway_lua.h"
 #include "milkyway_util.h"
 

--- a/separation/CMakeLists.txt
+++ b/separation/CMakeLists.txt
@@ -51,7 +51,11 @@ if(SYSTEM_IS_PPC)
   set(CMAKE_C_FLAGS "-maltivec -mfused-madd -mhard-float -mabi=altivec ${CMAKE_C_FLAGS}")
 endif()
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
 option(SEPARATION_STATIC "Build separation as fully static binary" OFF)
+else()
+option(SEPARATION_STATIC "Build separation as fully static binary" ON)
+endif()
 mark_as_advanced(SEPARATION_STATIC)
 
 


### PR DESCRIPTION
**Note: This compiles to a stub, not working yet, feel free to pick up**

This PR fixes some build issues and should at least allow `milkywayathome_client` to use Emscripten [emsdk](https://github.com/emscripten-core/emsdk)
to compile `lua`, `milkyway_nbody` and `milkyway_separation` in `.js` and `.wasm`

To workflow as follows:
1. Clone `emsdk` and `milkywayathome_client` repo
2. Check CMake version properly installed #82
3. `cd ./emsdk && . ./emsdk install latest && . ./emsdk activate latest && . ./emsdk_env.sh`
4. `mkdir -p build && cd ./build`
5. `emcmake cmake ../milkywayathome_client && make`
6. `node *.js` or `node --experimental-wasm-threads --experimental-wasm-bulk-memory *.js`

The goal is to replace step 6 with Chrome or Firefox if that's possible

In addition, the boinc api and lib need some adjustments that I am not willing to fork and make another PR
Its pretty ugly since its trying to update an older boinc source code to a newer one that has the Android specific codes
It still doesn't work anyway since Emscripten does not support POSIX signals and `setitimer()` that Android does

There's probably other myriad of issues not yet found and generally an inherent issue to BOINC itself that still not support Emscripten yet, even with the latest master
```
diff --git a/api/boinc_api.cpp b/api/boinc_api.cpp
index e9a0d13ae0..404a3a4b78 100644
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -112,6 +112,8 @@ using std::vector;

 #ifdef __APPLE__
 #include "mac_backtrace.h"
+#endif
+#if defined(__APPLE__) || defined(ANDROID) || defined(__EMSCRIPTEN__)
 #define GETRUSAGE_IN_TIMER_THREAD
     // call getrusage() in the timer thread,
     // rather than in the worker thread's signal handler
@@ -831,6 +833,11 @@ static void exit_from_timer_thread(int status) {
     //
     worker_thread_exit_status = status;
     worker_thread_exit_flag = true;
+#if defined(ANDROID) || defined(__EMSCRIPTEN__)
+    pthread_kill(worker_thread_handle, SIGALRM);
+    sleep(1.0);
+    boinc_exit(status);
+#endif
     pthread_exit(NULL);
 #endif
 }
@@ -1162,6 +1169,9 @@ static void timer_handler() {
             handle_process_control_msg();
         }
     }
+#if defined(ANDROID) || defined(__EMSCRIPTEN__)
+    pthread_kill(worker_thread_handle, SIGALRM);
+#endif
     if (interrupt_count % TIMERS_PER_SEC) return;

 #ifdef DEBUG_BOINC_API
@@ -1270,7 +1280,7 @@ static void worker_signal_handler(int) {
     }
     if (options.direct_process_action) {
         while (boinc_status.suspended && in_critical_section==0) {
-#ifdef ANDROID
+#if 0
             // per-thread signal masking doesn't work
             // on old (pre-4.1) versions of Android.
             // If we're handling this signal in the timer thread,
@@ -1346,23 +1356,29 @@ int start_timer_thread() {
 static int start_worker_signals() {
     int retval;
     struct sigaction sa;
-    itimerval value;
+    //itimerval value;
+    memset(&sa, 0, sizeof(sa));
     sa.sa_handler = worker_signal_handler;
     sa.sa_flags = SA_RESTART;
     sigemptyset(&sa.sa_mask);
     retval = sigaction(SIGALRM, &sa, NULL);
     if (retval) {
-        perror("boinc start_timer_thread() sigaction");
+        //perror("boinc start_timer_thread() sigaction");
+       perror("boinc start_worker_signals(): sigaction failed");
         return retval;
     }
+#if !defined(ANDROID) && !defined(__EMSCRIPTEN__)
+    itimerval value;
     value.it_value.tv_sec = 0;
     value.it_value.tv_usec = (int)(TIMER_PERIOD*1e6);
     value.it_interval = value.it_value;
     retval = setitimer(ITIMER_REAL, &value, NULL);
     if (retval) {
-        perror("boinc start_timer_thread() setitimer");
+        //perror("boinc start_timer_thread() setitimer");
+       perror("boinc start_worker_thread(): setitimer failed");
         return retval;
     }
+#endif
     return 0;
 }
 #endif
diff --git a/lib/shmem.cpp b/lib/shmem.cpp
index 19d63cd486..33f28c5d9f 100644
--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -395,7 +395,7 @@ int detach_shmem_mmap(void* p, size_t size) {
     return munmap((char *)p, size);
 }

-#if HAVE_SYS_SHM_H && !defined(ANDROID)
+#if HAVE_SYS_SHM_H && !defined(ANDROID) && !defined(__EMSCRIPTEN__)

 // Compatibility routines for Unix/Linux/Mac V5 applications
 //
diff --git a/lib/str_replace.h b/lib/str_replace.h
index b9d19617ed..f03281c7f1 100644
--- a/lib/str_replace.h
+++ b/lib/str_replace.h
@@ -32,6 +32,10 @@
 #include <ctype.h>
 #endif

+#ifdef __EMSCRIPTEN__
+#define HAVE_STRCASESTR 1
+#endif
+
 // strlcpy and strlcat guarantee NULL-terminated result
 // (unlike strncpy and strncat)
 //
```