### PR TITLE
add a space for LLU

### DIFF
--- a/milkyway/include/milkyway_extra.h
+++ b/milkyway/include/milkyway_extra.h
@@ -79,7 +79,7 @@ typedef char mwbool;
   #define LLU "%I64u"
 #else
   #define ZU "%zu"
-  #define LLU "%"PRIu64
+  #define LLU "%" PRIu64
 #endif /* _WIN32 */
 
 #endif /* _MILKYWAY_EXTRA_H_ */


### PR DESCRIPTION
invalid suffix on literal; C++11 requires a space between literal and identifier