### PR TITLE
Cutoff NFW, Gamma function and other small updates/bug fixes

### DIFF
--- a/milkyway/include/milkyway_math_double.h
+++ b/milkyway/include/milkyway_math_double.h
@@ -78,7 +78,7 @@ typedef MW_ALIGN_TYPE_V(32) double double4[4];
 #define mw_abs   fabs
 
 #define mw_acosh acosh
-#define mw_acospi(x) (mw_acos(x) / M_PI))
+#define mw_acospi(x) (mw_acos(x) / M_PI)
 #define mw_asinh asinh
 #define mw_asinpi (mw_asin(x) / M_PI)
 #define mw_atan2 atan2

--- a/nbody/include/nbody_mass.h
+++ b/nbody/include/nbody_mass.h
@@ -32,7 +32,11 @@ real probability_match(int n, real k, real pobs);
 
 real GammaFunc(const real z);
 
-real IncompleteGammaFunc(real a, real x);
+real UpperIncompleteGammaFunc(real a, real x);
+real LowerIncompleteGammaFunc(real a, real x);
+real ErrorFunc(real x);
+real ComplementaryErrorFunc(real x);
+real ComplementaryErrorFuncApprox(real x);
 
 real nbCostComponent(const NBodyHistogram* data, const NBodyHistogram* histogram);
 

--- a/nbody/include/nbody_particle_data.h
+++ b/nbody/include/nbody_particle_data.h
@@ -7,8 +7,11 @@
 typedef struct {
     int simple_output;  
     int has_milkyway;     
+    int has_lmc;
     real com_x, com_y, com_z; 
     real cmom_x, cmom_y, cmom_z;
+    real lmc_pos_x, lmc_pos_y, lmc_pos_z;
+    real lmc_vel_x, lmc_vel_y, lmc_vel_z;
 } ParticleHeader;
 
 // Structure to hold data for a single particle (one row)

--- a/nbody/include/nbody_potential_types.h
+++ b/nbody/include/nbody_potential_types.h
@@ -185,8 +185,7 @@ typedef struct MW_ALIGN_TYPE
 #define EMPTY_DISK { InvalidDisk, 0.0, 0.0, 0.0, 0.0, 0.0 }
 #define EMPTY_DISK2 { InvalidDisk, 0.0, 0.0, 0.0, 0.0, 0.0 }
 #define EMPTY_HALO { InvalidHalo, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
-#define EMPTY_DWARF { InvalidDwarf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+#define EMPTY_DWARF { InvalidDwarf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 #define EMPTY_POTENTIAL { {EMPTY_SPHERICAL}, EMPTY_DISK, EMPTY_DISK2, EMPTY_HALO, NULL }
 
 #endif /* _NBODY_POTENTIAL_TYPES_H_ */
-

--- a/nbody/include/nbody_potential_types.h
+++ b/nbody/include/nbody_potential_types.h
@@ -162,6 +162,8 @@ typedef struct MW_ALIGN_TYPE
     real p0; //used by nfw and cored
     real r200; // virial radius
     real ps, r1, rc; //used by cored
+    real rcut, rdecay, pcut, delta, m_nfw_cut, gamma1, psi_nfw_cut, psi_cut_cut;   // NFW cutoff constants
+    real m_nfw_r1, m_iso_r1, psi_nfw_r1, psi_iso_r1; // extra constants for cutoff Cored profiles
 } Dwarf;
 
 #define DWARF_TYPE "Dwarf"
@@ -183,7 +185,7 @@ typedef struct MW_ALIGN_TYPE
 #define EMPTY_DISK { InvalidDisk, 0.0, 0.0, 0.0, 0.0, 0.0 }
 #define EMPTY_DISK2 { InvalidDisk, 0.0, 0.0, 0.0, 0.0, 0.0 }
 #define EMPTY_HALO { InvalidHalo, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
-#define EMPTY_DWARF { InvalidDwarf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+#define EMPTY_DWARF { InvalidDwarf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
 #define EMPTY_POTENTIAL { {EMPTY_SPHERICAL}, EMPTY_DISK, EMPTY_DISK2, EMPTY_HALO, NULL }
 
 #endif /* _NBODY_POTENTIAL_TYPES_H_ */

--- a/nbody/sample_workunits/for_developers.lua
+++ b/nbody/sample_workunits/for_developers.lua
@@ -22,7 +22,7 @@
 
 -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
 -- Structural changes to this file also need to be changed in the 
--- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/) and (nbody/tests/orphan_models/)
 -- especially if the changes are not backwards compatible with the previous format
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
@@ -52,7 +52,7 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalBodies           = 40000       -- -- NUMBER OF TOTAL BODIES                                               -- --
 totalLightBodies      = 20000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
 
 nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --

--- a/nbody/sample_workunits/for_developers.lua
+++ b/nbody/sample_workunits/for_developers.lua
@@ -22,7 +22,7 @@
 
 -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
 -- Structural changes to this file also need to be changed in the 
--- lua files in the test_env_lua directory (nbody/sample_workunits/test_env_lua/)
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
 -- especially if the changes are not backwards compatible with the previous format
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
@@ -52,18 +52,18 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 2485781     -- -- NUMBER OF TOTAL BODIES                                               -- --
-totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 20000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
 
 nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
 nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
 
-run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+run_null_potential    = false       -- -- NULL POTENTIAL SWITCH                                                -- --
 use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
 print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
 print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
 
-LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_body              = true        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
 LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
 LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
 LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
@@ -178,7 +178,7 @@ end
 --component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
 --calculate dwarf-based softening length
 comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-comp2 = Dwarf.cored{mass = mass_d, scaleLength = rscale_d, r1 = 0.7, rc = 0.6, rcut = 4.5} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.plummer{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
 
 
 
@@ -240,16 +240,16 @@ numCalibrationRuns = 0
 -- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
 
-useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+useMultiOutputs       = false     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
 freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
 
 timestep_control      = false       -- -- control number of steps                                                          -- --
-Ntime_steps           = 1        -- -- number of timesteps to run                                                       -- --
+Ntime_steps           = 3000        -- -- number of timesteps to run                                                       -- --
 
 use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
 max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
 
-generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
+generateInitialOutput = false       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         
         

--- a/nbody/sample_workunits/for_developers.lua
+++ b/nbody/sample_workunits/for_developers.lua
@@ -52,18 +52,18 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 40000       -- -- NUMBER OF TOTAL BODIES                                               -- --
-totalLightBodies      = 20000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+totalBodies           = 2485781     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
 
 nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
 nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
 
-run_null_potential    = false       -- -- NULL POTENTIAL SWITCH                                                -- --
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
 use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
 print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
 print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
 
-LMC_body              = true        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
 LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
 LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
 LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
@@ -178,7 +178,7 @@ end
 --component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
 --calculate dwarf-based softening length
 comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-comp2 = Dwarf.plummer{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.cored{mass = mass_d, scaleLength = rscale_d, r1 = 0.7, rc = 0.6, rcut = 4.5} -- Dwarf Options: plummer, nfw, general_hernquist, cored
 
 
 
@@ -240,16 +240,16 @@ numCalibrationRuns = 0
 -- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
 
-useMultiOutputs       = false     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
 freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
 
 timestep_control      = false       -- -- control number of steps                                                          -- --
-Ntime_steps           = 3000        -- -- number of timesteps to run                                                       -- --
+Ntime_steps           = 1        -- -- number of timesteps to run                                                       -- --
 
 use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
 max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
 
-generateInitialOutput = false       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         
         
@@ -263,11 +263,11 @@ function makePotential()
    else
         --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
         return  Potential.create{
-            spherical = Spherical.hernquist{ mass  = 1.52954402e5, scale = 0.7 },
-            disk      = Disk.miyamotoNagai{ mass = 4.45865888e5, scaleLength = 6.5, scaleHeight = 0.26 },
-            disk2     = Disk.none{ mass = 3.0e5 },
-            halo      = Halo.logarithmic{ vhalo = 74.61, scaleLength = 12.0, flattenZ = 1.0 }
-        }--vhalo = 74.61 kpc/gy = 73 km/s
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
    end
 end
 
@@ -332,7 +332,7 @@ function makeContext()
       timeEvolve  = evolveTime,
       timeBack    = revOrbTime,
       timestep    = get_timestep(),
-      eps2        = get_soft_par(), 
+      eps2        = 1e-4, 
       b           = orbit_parameter_b,
       r           = orbit_parameter_r,
       vx          = orbit_parameter_vx,

--- a/nbody/sample_workunits/for_developers.lua
+++ b/nbody/sample_workunits/for_developers.lua
@@ -332,7 +332,7 @@ function makeContext()
       timeEvolve  = evolveTime,
       timeBack    = revOrbTime,
       timestep    = get_timestep(),
-      eps2        = 1e-4, 
+      eps2        = get_soft_par(), 
       b           = orbit_parameter_b,
       r           = orbit_parameter_r,
       vx          = orbit_parameter_vx,

--- a/nbody/src/nbody_dwarf_potential.c
+++ b/nbody/src/nbody_dwarf_potential.c
@@ -60,11 +60,24 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /*                            NFW                                                                                        */
 /* this density is taken from the 1997 paper by nfw. the potential is taken from binney 2nd ed                           */
+/* Cutoff for density is addapted from Zemp et al. 2008                                                                  */
  static real nfw_den(const Dwarf* model, real r)                                                                         //
 {                                                                                                                        //
     const real rscale = model->scaleLength;                                                                              //
     const real p0 = model->p0;                                                                                           //
+    const real rcut = model->rcut;                                                                                       //
     real R = r / rscale;                                                                                                 //
+    if (rcut != 0.0) {                                                                                                   //
+        const real rdecay = model->rdecay;                                                                               //
+        const real pcut = model->pcut;                                                                                   //
+        const real delta = model->delta;                                                                                 //
+        if (r > rcut) {                                                                                                  //
+            return pcut * mw_pow(r / rcut, delta) * mw_exp(-(r - rcut) / rdecay);                                        //
+        }                                                                                                                //
+        else {                                                                                                           //
+            return p0 * inv(R) * inv(sqr(1.0 + R));                                                                      //
+        }                                                                                                                //
+    }                                                                                                                    //
     /* at r = 0 the density goes to inf. however, the sampling is guarded against r = 0 anyway.*/                        //
     return p0 * inv(R) * inv(sqr(1.0 + R));                                                                              //
 }                                                                                                                        //
@@ -73,7 +86,28 @@
 {                                                                                                                        //
     const real rscale = model->scaleLength;                                                                              //
     const real p0 = model->p0;                                                                                           //
+    const real rcut = model->rcut;                                                                                       //
     real R = r / rscale;                                                                                                 //
+    if (rcut != 0.0) {                                                                                                   //
+        const real rdecay = model->rdecay;                                                                               //
+        const real pcut = model->pcut;                                                                                   //
+        const real delta = model->delta;                                                                                 //
+        const real m_nfw_cut = model->m_nfw_cut;                                                                         //
+        const real gamma1 = model->gamma1;                                                                               //
+        if (r > rcut) {                                                                                                  //
+            return (                                                                                                     //
+                4.0 * M_PI * pcut * mw_pow(rcut, -delta) * mw_exp(rcut / rdecay) * mw_pow(rdecay, delta + 3)             //
+                * (((gamma1 - UpperIncompleteGammaFunc(delta + 3, r / rdecay)) / r)                                      //
+                + (UpperIncompleteGammaFunc(delta + 2, r / rdecay) / rdecay)) + m_nfw_cut / r                            //
+            );                                                                                                           //
+        } else {                                                                                                         //
+            const real psi_nfw_cut = model->psi_nfw_cut;                                                                 //
+            const real psi_cut_cut = model->psi_cut_cut;                                                                 //
+            const real m_nfw_cut = model->m_nfw_cut;                                                                     //
+            return (4.0 * M_PI * p0 * cube(rscale) * mw_log(1.0 + R) * inv(r)                                            //
+                - psi_nfw_cut + psi_cut_cut + m_nfw_cut / rcut);                                                         //
+        }                                                                                                                //
+    }                                                                                                                    //
     /* at r = 0 the pot goes to inf. however, the sampling is guarded against r = 0 anyway. */                           //
     return  4.0 * M_PI * sqr(rscale) * p0 * inv(R) * mw_log(1.0 + R);                                                    //
 }                                                                                                                        //
@@ -112,7 +146,8 @@ static real gen_hern_vel_disp(const Dwarf* model, real r)                       
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /*                             EINASTO                                                                                   */
 /* these are taken from the einasto paper. There are many problems with this, so it is currently unused.                 */
-static real einasto_den(const Dwarf* model, real r)                                                                      //                                                                     //
+/* Might be fixed now that gamma functions are now working correctly.                                                    */
+static real einasto_den(const Dwarf* model, real r)                                                                      //                                                                     
 {                                                                                                                        //
     const real mass __attribute__((unused)) = model->mass;                                                               //
     const real h = model->scaleLength;                                                                                   //
@@ -132,8 +167,8 @@ static real einasto_pot(const Dwarf* model, real r)                             
     real coeff = mass / (h * r);                                                                                         //
     real thing = mw_pow(r, 1.0 / n);                                                                                     //
                                                                                                                          //
-    real term1 = IncompleteGammaFunc(3.0 * n, thing);                                                                    //
-    real term2 = r * IncompleteGammaFunc(2.0 * n, thing);                                                                //
+    real term1 = UpperIncompleteGammaFunc(3.0 * n, thing);                                                               //
+    real term2 = r * UpperIncompleteGammaFunc(2.0 * n, thing);                                                           //
     real term = 1.0 - ( term1 + term2 ) / GammaFunc(3.0 * n);                                                            //
     return coeff * term;                                                                                                 //
 }                                                                                                                        //
@@ -147,23 +182,30 @@ static real einasto_vel_disp(const Dwarf* model, real r)                        
 }                                                                                                                        //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /*                             CORED                                                                                     */
-/* this potential and density are cored profiles to be used with SIDM.                                                   */
+/* this potential and density are cored NFW profiles to be used with SIDM.                                               */
 static real cored_den(const Dwarf* model, real r)                                                                        //
 {                                                                                                                        //
     const real r1 = model->r1;                                                                                           //
-    real p = 0.0;                                                                                                        //
-    real rscale = 0.0;                                                                                                   //
-    if(r <= r1)                                                                                                          //
+    const real rcut = model->rcut;                                                                                       //
+                                                                                                                         //
+    if (rcut != 0.0 && r > rcut)                                                                                         //
     {                                                                                                                    //
-        p = model->p0;                                                                                                   //
-        rscale = model->rc;                                                                                              //
-        return p / (1.0 + sqr(r / rscale));                                                                              //
+        const real pcut = model->pcut;                                                                                   //
+        const real delta = model->delta;                                                                                 //
+        const real rdecay = model->rdecay;                                                                               //
+        return pcut * mw_pow(r / rcut, delta) * mw_exp(-(r - rcut) / rdecay);                                            //
+    }                                                                                                                    //
+    else if (r <= r1)                                                                                                    //
+    {                                                                                                                    //
+        const real p0 = model->p0;                                                                                       //
+        const real rc = model->rc;                                                                                       //
+        return p0 / (1.0 + sqr(r / rc));                                                                                 //
     }                                                                                                                    //
     else                                                                                                                 //
     {                                                                                                                    //
-        p = model->ps;                                                                                                   //
-        rscale = model->scaleLength;                                                                                     //
-        return p / ((r / rscale) * sqr(1.0 + r / rscale));                                                               //
+        const real ps = model->ps;                                                                                       //
+        const real rs = model->scaleLength;                                                                              //
+        return ps / ((r / rs) * sqr(1.0 + r / rs));                                                                      //
     }                                                                                                                    //
 }                                                                                                                        //
                                                                                                                          //
@@ -174,32 +216,57 @@ static real cored_pot(const Dwarf* model, real r)                               
     const real rc = model->rc;                                                                                           //
     const real ps = model->ps;                                                                                           //
     const real rs = model->scaleLength;                                                                                  //
-    const real C3 = 4.0 * M_PI * (                                                                                       //
-            ps * cube(rs) * (                                                                                            //
-                mw_log((1.0 + r1 / rs)) - r1 / (rs + r1)                                                                 //
-            )                                                                                                            //
-            - p0 * sqr(rc) * (                                                                                           //
-                r1 - rc * mw_atan(r1 / rc)                                                                               //
-            )                                                                                                            //
-        );                                                                                                               //
+    const real rcut = model->rcut;                                                                                       //
+    const real m_iso_r1 = model->m_iso_r1;                                                                               //
+    const real m_nfw_r1 = model->m_nfw_r1;                                                                               //
+    const real m_nfw_cut = model->m_nfw_cut;                                                                             //
                                                                                                                          //
-    if(r <= r1)                                                                                                          //
+    if (rcut != 0.0 && r > rcut)                                                                                         //
     {                                                                                                                    //
-            const real C2 = C3 / r1 - (4.0 * M_PI) / r1 * (                                                              //
-            ps * cube(rs) * mw_log(1 + r1 / rs) +                                                                        //
-            p0 * (                                                                                                       //
-                (sqr(rc) * r1) / 2.0 * mw_log(sqr(r1) + sqr(rc)) +                                                       //
-                cube(rc) * mw_atan(r1 / rc)                                                                              //
-            )                                                                                                            //
+        const real pcut = model->pcut;                                                                                   //
+        const real delta = model->delta;                                                                                 //
+        const real rdecay = model->rdecay;                                                                               //
+        const real gamma1 = model->gamma1;                                                                               //
+        return (                                                                                                         //
+            4.0 * M_PI * pcut * mw_pow(rcut, -delta) * mw_exp(rcut / rdecay) * mw_pow(rdecay, delta + 3)                 //
+            * (((gamma1 - UpperIncompleteGammaFunc(delta + 3, r / rdecay)) * inv(r))                                     //
+            + (UpperIncompleteGammaFunc(delta + 2, r / rdecay) * inv(rdecay)))                                           //
+            + ((m_nfw_cut + m_iso_r1 - m_nfw_r1) * inv(r))                                                               //
         );                                                                                                               //
-        return -1.0 * (4.0 * M_PI * p0 * (                                                                               //
-            sqr(rc) / 2.0 * mw_log(sqr(r) + sqr(rc)) +                                                                   //
-            cube(rc) / r * mw_atan(r / rc)                                                                               //
-        ) + C2);                                                                                                         //
+    }                                                                                                                    //
+    else if (r <= r1)                                                                                                    //
+    {                                                                                                                    //
+        const real p0 = model->p0;                                                                                       //
+        const real rc = model->rc;                                                                                       //
+        const real psi_iso_r1 = model->psi_iso_r1;                                                                       //
+        const real psi_nfw_r1 = model->psi_nfw_r1;                                                                       //
+        real psi = (                                                                                                     //
+            -4.0 * M_PI * p0 * sqr(rc) * ((mw_log(sqr(rc) + sqr(r)) * inv(2.0)) + ((rc * mw_atan(r / rc) * inv(r))))     //
+            - psi_iso_r1 + psi_nfw_r1 + ((m_iso_r1 - m_nfw_r1) * inv(r1))                                                //
+        );                                                                                                               //
+        if (rcut != 0.0) {                                                                                               //
+            const real psi_nfw_cut = model->psi_nfw_cut;                                                                 //
+            const real psi_cut_cut = model->psi_cut_cut;                                                                 //
+            psi += -psi_nfw_cut - ((m_iso_r1 - m_nfw_r1) * inv(rcut))                                                    //
+                + psi_cut_cut + ((m_nfw_cut + m_iso_r1 - m_nfw_r1) * inv(rcut));                                         //
+        }                                                                                                                //
+        return psi;                                                                                                      //
     }                                                                                                                    //
     else                                                                                                                 //
     {                                                                                                                    //
-            return  -1.0 * (-4.0 * M_PI * ps * cube(rs) / r * mw_log(1.0 + r / rs) + C3 / r);                            //
+        const real ps = model->ps;                                                                                       //
+        const real rs = model->scaleLength;                                                                              //
+        real psi = (                                                                                                     //
+            4.0 * M_PI * ps * cube(rs) * inv(r) * mw_log(1.0 + r / rs) + ((m_iso_r1 - m_nfw_r1) * inv(r))                //
+        );                                                                                                               //
+        if (rcut != 0.0) {                                                                                               //
+            const real psi_nfw_cut = model->psi_nfw_cut;                                                                 //
+            const real psi_cut_cut = model->psi_cut_cut;                                                                 //
+            const real m_nfw_cut = model->m_nfw_cut;                                                                     //
+            psi += -psi_nfw_cut - ((m_iso_r1 - m_nfw_r1) * inv(rcut))                                                    //
+                + psi_cut_cut + ((m_nfw_cut + m_iso_r1 - m_nfw_r1) * inv(rcut));                                         //
+        }                                                                                                                //
+        return psi;                                                                                                      //
     }                                                                                                                    //
 }                                                                                                                        //
                                                                                                                          //

--- a/nbody/src/nbody_io.c
+++ b/nbody/src/nbody_io.c
@@ -48,9 +48,11 @@ static void nbPrintSimInfoHeader(FILE* f, const NBodyCtx* ctx, const NBodyState*
     fprintf(f,
             "simple_output = %d\n"
             "hasMilkyway  = %d\n"
+            "hasLMC       = %d\n"
             "centerOfMass = %f, %f, %f,   centerOfMomentum = %f, %f, %f,\n",
             ctx->SimpleOutput,
             (ctx->potentialType == EXTERNAL_POTENTIAL_DEFAULT),
+            ctx->LMC,
             X(cmPos), Y(cmPos), Z(cmPos),
             X(cmVel), Y(cmVel), Z(cmVel)
         );

--- a/nbody/src/nbody_lua_types/nbody_lua_dwarf.c
+++ b/nbody/src/nbody_lua_types/nbody_lua_dwarf.c
@@ -65,6 +65,11 @@ static int createPlummerDwarf(lua_State* luaSt)
         };
 
     h.type = Plummer;
+    oneTableArgument(luaSt, argTable);
+    if (h.mass <= 0.0)
+        luaL_error(luaSt, "Plummer dwarf mass must be positive");
+    if (h.scaleLength <= 0.0)
+        luaL_error(luaSt, "Plummer dwarf scaleLength must be positive");
     return createDwarf(luaSt, argTable, &h);
 }
 
@@ -82,6 +87,13 @@ static int createNFWDwarf(lua_State* luaSt)
     /* Defaults: rcut = 0.0 (no cutoff) */
     h.type = NFW;
     h.rcut = 0.0;
+    oneTableArgument(luaSt, argTable);
+    if (h.mass <= 0.0)
+        luaL_error(luaSt, "NFW dwarf mass must be positive");
+    if (h.scaleLength <= 0.0)
+        luaL_error(luaSt, "NFW dwarf scaleLength must be positive");
+    if (h.rcut < 0.0)
+        luaL_error(luaSt, "NFW dwarf rcut must be non-negative");
     return createDwarf(luaSt, argTable, &h);
 }
 
@@ -96,6 +108,11 @@ static int createGen_HernDwarf(lua_State* luaSt)
         };
 
     h.type = General_Hernquist;
+    oneTableArgument(luaSt, argTable);
+    if (h.mass <= 0.0)
+        luaL_error(luaSt, "General Hernquist dwarf mass must be positive");
+    if (h.scaleLength <= 0.0)
+        luaL_error(luaSt, "General Hernquist dwarf scaleLength must be positive");
     return createDwarf(luaSt, argTable, &h);
 }
 
@@ -111,6 +128,13 @@ static int createEinastoDwarf(lua_State* luaSt)
         };
 
     h.type = Einasto;
+    oneTableArgument(luaSt, argTable);
+    if (h.mass <= 0.0)
+        luaL_error(luaSt, "Einasto dwarf mass must be positive");
+    if (h.scaleLength <= 0.0)
+        luaL_error(luaSt, "Einasto dwarf scaleLength must be positive");
+    if (h.n <= 0.0)
+        luaL_error(luaSt, "Einasto dwarf n must be positive");
     return createDwarf(luaSt, argTable, &h);
 }
 
@@ -130,6 +154,19 @@ static int createCoredDwarf(lua_State* luaSt)
     h.type = Cored;
 	h.r1 = h.scaleLength;
 	h.rcut = 0.0;
+    oneTableArgument(luaSt, argTable);
+    if (h.mass <= 0.0)
+        luaL_error(luaSt, "Cored dwarf mass must be positive");
+    if (h.scaleLength <= 0.0)
+        luaL_error(luaSt, "Cored dwarf scaleLength must be positive");
+    if (h.r1 <= 0.0)
+        luaL_error(luaSt, "Cored dwarf r1 must be positive");
+    if (h.rc <= 0.0)
+        luaL_error(luaSt, "Cored dwarf rc must be positive");
+    if (h.rcut < 0.0)
+        luaL_error(luaSt, "Cored dwarf rcut must be non-negative");
+    if (h.rcut != 0.0 && h.rcut < h.r1)
+        luaL_error(luaSt, "Cored dwarf rcut must be no less than r1");
     return createDwarf(luaSt, argTable, &h);
 }
 

--- a/nbody/src/nbody_lua_types/nbody_lua_dwarf.c
+++ b/nbody/src/nbody_lua_types/nbody_lua_dwarf.c
@@ -75,10 +75,13 @@ static int createNFWDwarf(lua_State* luaSt)
         {
             { "mass",        LUA_TNUMBER, NULL, TRUE, &h.mass,        1 },
             { "scaleLength", LUA_TNUMBER, NULL, TRUE, &h.scaleLength, 1 },
+            { "rcut",        LUA_TNUMBER, NULL, FALSE, &h.rcut,       1 },
             END_MW_NAMED_ARG
         };
-
+    
+    /* Defaults: rcut = 0.0 (no cutoff) */
     h.type = NFW;
+    h.rcut = 0.0;
     return createDwarf(luaSt, argTable, &h);
 }
 
@@ -120,11 +123,13 @@ static int createCoredDwarf(lua_State* luaSt)
             { "scaleLength", LUA_TNUMBER, NULL, TRUE, &h.scaleLength, 1 },
 			{ "r1", 		 LUA_TNUMBER, NULL, TRUE, &h.r1,          1 },
 			{ "rc", 		 LUA_TNUMBER, NULL, TRUE, &h.rc,          1 },
+			{ "rcut", 	     LUA_TNUMBER, NULL, FALSE, &h.rcut,       1 },
             END_MW_NAMED_ARG
         };
 
     h.type = Cored;
 	h.r1 = h.scaleLength;
+	h.rcut = 0.0;
     return createDwarf(luaSt, argTable, &h);
 }
 

--- a/nbody/src/nbody_mass.c
+++ b/nbody/src/nbody_mass.c
@@ -82,7 +82,9 @@ real probability_match(int n, real ktmp, real pobs)
 }
 // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // 
 // IMPLEMENTATION OF GAMMA FUNCTIONS. COMPLETE AND INCOMPLETE
-real GammaFunc(const real z) 
+// These functions are adapted from the Numerical Recipes in C 2nd ed except for gammln.
+/* Returns ln(Gamma(z)) via the Lanczos approximation (NR 3rd ed). */
+real gammln(const real z) 
 {
     //Alogrithm for the calculation of the Lanczos Approx of the complete Gamma function 
     //as implemented in Numerical Recipes 3rd ed, 2007.
@@ -108,67 +110,193 @@ real GammaFunc(const real z)
     //sqrt(2 * pi) = 2.5066282746310005
     tmp += mw_log(2.5066282746310005 * A_g / x);//returns the log of the gamma function
     
-    return mw_exp(tmp);
+    return tmp;
 }
 
-static real shift_factorial(real z, real n)
+/*
+ * Returns the incomplete gamma function P(a, x), evaluated by its
+ * series representation. Also returns ln(Gamma(a)) through gln.
+ */
+static real gser(const real a, const real x, real* gln)
 {
-    int counter;
-    real result = 0.0;
-    for(counter = n; counter >= 1; counter--)
-    {
-        result += mw_log(z + (real) counter);
-    }
-    return mw_exp(result);
-    
-    
-}
-
-
-static real series_approx(real a, real x)
-{
-
+    const int itmax = 100;
+    const real eps = (real) 3.0e-7;
     real sum, del, ap;
-    real pow_x = 1.0;
-//     ap = a;
-    ap = 0.0;
-    del = sum = 1.0 / a;//starting: gammma(a) / gamma(a+1) = 1/a
-    for (;;) 
-    {
-//         ++ap;
-        ++ap;
-//         del *= x / ap;
 
-        pow_x *= x;
-        del = pow_x / (a * shift_factorial(a, ap));
-        
+    *gln = gammln(a);
+    if (x <= 0.0)
+    {
+        return 0.0;
+    }
+
+    ap = a;
+    del = sum = 1.0 / a;
+    for (int n = 1; n <= itmax; ++n)
+    {
+        ap += 1.0;
+        del *= x / ap;
         sum += del;
-        if (mw_fabs(del) < mw_fabs(sum) * 1.0e-15) 
+        if (mw_fabs(del) < mw_fabs(sum) * eps)
         {
-            return sum * mw_exp(-x + a * mw_log(x));
+            return sum * mw_exp(-x + a * mw_log(x) - (*gln));
         }
     }
-    
+
+    mw_printf("WARNING: gser did not converge (a=%f, x=%f)\n", a, x);
+    return sum * mw_exp(-x + a * mw_log(x) - (*gln));
 }
-                            
-real IncompleteGammaFunc(real a, real x)
+
+/*
+ * Returns the incomplete gamma function Q(a, x), evaluated by its
+ * continued-fraction representation (modified Lentz method).
+ * Also returns ln(Gamma(a)) through gln.
+ */
+static real gcf(const real a, const real x, real* gln)
 {
-    //the series approx returns gamma from 0 to X but we want from X to INF
-    //Therefore, we subtract it from GammaFunc which is from 0 to INF
-    //The continued frac approx is already from X to INF
-    
-//     static const real max_a = 100;
-    real gamma = GammaFunc(a);
+    const int itmax = 100;
+    const real eps = (real) 3.0e-7;
+    const real fpmin = (real) 1.0e-30;
+    real an, b, c, d, del, h;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wfloat-equal"
-    if (x == 0.0) return gamma;
-#pragma GCC diagnostic pop
-    // Use the series representation. 
-    return gamma - series_approx(a,x);
-    
+    *gln = gammln(a);
+    b = x + 1.0 - a;
+    if (mw_fabs(b) < fpmin)
+    {
+        b = fpmin;
+    }
+    c = 1.0 / fpmin;
+    d = 1.0 / b;
+    h = d;
 
-}    
+    for (int i = 1; i <= itmax; ++i)
+    {
+        an = -(real) i * ((real) i - a);
+        b += 2.0;
+        d = an * d + b;
+        if (mw_fabs(d) < fpmin)
+        {
+            d = fpmin;
+        }
+        c = b + an / c;
+        if (mw_fabs(c) < fpmin)
+        {
+            c = fpmin;
+        }
+        d = 1.0 / d;
+        del = d * c;
+        h *= del;
+        if (mw_fabs(del - 1.0) < eps)
+        {
+            return mw_exp(-x + a * mw_log(x) - (*gln)) * h;
+        }
+    }
+
+    mw_printf("WARNING: gcf did not converge (a=%f, x=%f)\n", a, x);
+    return mw_exp(-x + a * mw_log(x) - (*gln)) * h;
+}
+
+/*
+ * Returns the regularized lower incomplete gamma function:
+ * P(a, x) = gamma(a, x) / Gamma(a).
+ * Uses series for x < a + 1, otherwise returns 1 - Q(a, x).
+ */
+real gammp(const real a, const real x)
+{
+    real gln;
+
+    if (x < 0.0 || a <= 0.0)
+    {
+        mw_printf("WARNING: Invalid arguments in gammp (a=%f, x=%f)\n", a, x);
+        return NAN;
+    }
+
+    if (x < (a + 1.0))
+    {
+        return gser(a, x, &gln);
+    }
+    return 1.0 - gcf(a, x, &gln);
+}
+
+/*
+ * Returns the regularized upper incomplete gamma function:
+ * Q(a, x) = Gamma(a, x) / Gamma(a) = 1 - P(a, x).
+ * Uses series for x < a + 1, otherwise continued fraction.
+ */
+real gammq(const real a, const real x)
+{
+    real gln;
+
+    if (x < 0.0 || a <= 0.0)
+    {
+        mw_printf("WARNING: Invalid arguments in gammq (a=%f, x=%f)\n", a, x);
+        return NAN;
+    }
+
+    if (x < (a + 1.0))
+    {
+        return 1.0 - gser(a, x, &gln);
+    }
+    return gcf(a, x, &gln);
+}
+
+/* Returns the complete gamma function Gamma(z). */
+real GammaFunc(const real z)
+{
+    return mw_exp(gammln(z));
+}
+
+/* Returns the upper incomplete gamma function Gamma(a, x). */
+real UpperIncompleteGammaFunc(real a, real x)
+{
+    return GammaFunc(a) * gammq(a, x);
+}
+
+/* Returns the lower incomplete gamma function Gamma(a, x). */
+real LowerIncompleteGammaFunc(real a, real x)
+{
+    return GammaFunc(a) * gammp(a, x);
+}
+
+/*
+ * Numerical Recipes erff(x):
+ * returns erf(x) using the regularized incomplete gamma P(1/2, x^2).
+ */
+real ErrorFunc(real x)
+{
+    const real xsq = x * x;
+    return (x < 0.0) ? -gammp(0.5, xsq) : gammp(0.5, xsq);
+}
+
+/*
+ * Numerical Recipes erffc(x):
+ * returns erfc(x) using P(1/2, x^2) for x < 0 and Q(1/2, x^2) for x >= 0.
+ */
+real ComplementaryErrorFunc(real x)
+{
+    const real xsq = x * x;
+    return (x < 0.0) ? 1.0 + gammp(0.5, xsq) : gammq(0.5, xsq);
+}
+
+/*
+ * Numerical Recipes erfcc(x):
+ * fast erfc approximation with fractional error < 1.2e-7.
+ */
+real ComplementaryErrorFuncApprox(real x)
+{
+    real z = mw_fabs(x);
+    real t = 1.0 / (1.0 + 0.5 * z);
+    real ans = t * mw_exp(-z * z - 1.26551223
+                          + t * (1.00002368
+                          + t * (0.37409196
+                          + t * (0.09678418
+                          + t * (-0.18628806
+                          + t * (0.27886807
+                          + t * (-1.13520398
+                          + t * (1.48851587
+                          + t * (-0.82215223
+                          + t * 0.17087277)))))))));
+    return (x >= 0.0) ? ans : 2.0 - ans;
+}
 
 // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // // 
 

--- a/nbody/src/nbody_mixeddwarf.c
+++ b/nbody/src/nbody_mixeddwarf.c
@@ -806,10 +806,10 @@ static inline void recalculate_comp_mass(Dwarf* comp, real bound)
             const real p0 = comp->p0;
             const real rcut = comp->rcut;
             if (rcut != 0.0) {
-                const real rdecay = comp->rdecay;
-                const real delta = comp->delta;
                 if (r > rcut)
                 {
+                    const real rdecay = comp->rdecay;
+                    const real delta = comp->delta;
                     const real pcut = comp->pcut;
                     const real gamma1 = comp->gamma1;
                     const real m_nfw_cut = comp->m_nfw_cut;

--- a/nbody/src/nbody_mixeddwarf.c
+++ b/nbody/src/nbody_mixeddwarf.c
@@ -30,6 +30,7 @@ their copyright to their programs which execute similar algorithms.
 #include "milkyway_lua.h"
 #include "nbody_lua_types.h"
 #include "nbody_dwarf_potential.h"
+#include "nbody_mass.h"
 #include "nbody_mixeddwarf.h"
 #include "nbody_types.h"
 #include "nbody_potential_types.h"
@@ -701,23 +702,65 @@ static inline void set_vars(Dwarf* comp)
     real term = mw_log(1.0 + c) - c / (1.0 + c);
     real p0 = 200.0 * cube(c) * pcrit / (3.0 * term); //rho_0 as defined in Navarro et. al. 1997
     real ps = 0.0;
-        if(comp->type == Cored)
-        {       
-                ps = p0; //characteristic density of the NFW portion of the cored profile 
-                real r1 = comp->r1;
-                real rc = comp->rc;
+    real rcut = comp->rcut;
+    real rdecay = 0.0;
+    real pcut = 0.0;
+    real delta = 0.0;
+    real m_nfw_cut = 0.0;
+    real gamma1 = 0.0;
+    real psi_nfw_cut = 0.0;
+    real psi_cut_cut = 0.0; 
+    real m_nfw_r1 = 0.0;
+    real m_iso_r1 = 0.0;
+    real psi_nfw_r1 = 0.0;
+    real psi_iso_r1 = 0.0;
 
-                real p0_ps = (rscale + rscale * sqr(r1 / rc)) / (r1 * sqr(1.0 + r1 / rscale)); //Ratio of p0 to ps
+    if (rcut != 0.0) {
+        rdecay = 0.3 * rcut;
+        pcut = p0 * inv(rcut / rscale) * inv(sqr(1.0 + rcut / rscale));
+        delta = (rcut / rdecay) - (1.0 + 3.0 * (rcut / rscale)) / (1.0 + (rcut / rscale));
+        m_nfw_cut = 4.0 * M_PI * p0 * cube(rscale) * (mw_log((rscale + rcut) / rscale) - rcut / (rscale + rcut));
+        gamma1 = UpperIncompleteGammaFunc(delta + 3, rcut / rdecay);
+        psi_nfw_cut = 4.0 * M_PI * p0 * cube(rscale) * mw_log(1.0 + rcut / rscale) * inv(rcut);
+        psi_cut_cut = 4.0 * M_PI * pcut * mw_pow(rcut, -delta) * mw_exp(rcut / rdecay) * mw_pow(rdecay, delta + 3) * (UpperIncompleteGammaFunc(delta + 2, rcut / rdecay) * inv(rdecay));
+    }
+    if(comp->type == Cored)
+    {       
+        ps = p0; //characteristic density of the NFW portion of the cored profile 
+        real r1 = comp->r1;
+        real rc = comp->rc;
 
-                p0 = ps * p0_ps; //central density of the cored profile
-        }
+        real p0_ps = (rscale + rscale * sqr(r1 / rc)) / (r1 * sqr(1.0 + r1 / rscale)); //Ratio of p0 to ps
+
+        p0 = ps * p0_ps; //central density of the cored profile
+
+        m_nfw_r1 = 4.0 * M_PI * ps * cube(rscale) * (mw_log((rscale + r1) / rscale) - r1 / (rscale + r1));
+        m_iso_r1 = 4.0 * M_PI * p0 * sqr(rc) * (r1 - rc * mw_atan(r1 / rc));
+        psi_nfw_r1 = 4.0 * M_PI * ps * cube(rscale) * mw_log(1.0 + r1 / rscale) * inv(r1);
+        psi_iso_r1 = -4.0 * M_PI * p0 * sqr(rc) * (mw_log(sqr(rc) + sqr(r1)) / 2.0 + rc * mw_atan(r1 / rc) / r1);
+
+    }
+
     comp->r200 = r200;
     comp->p0 = p0;
     comp->ps = ps;
+    comp->rdecay = rdecay;
+    comp->pcut = pcut;
+    comp->delta = delta;
+    comp->m_nfw_cut = m_nfw_cut;
+    comp->gamma1 = gamma1;
+    comp->psi_nfw_cut = psi_nfw_cut;
+    comp->psi_cut_cut = psi_cut_cut;
+    comp->m_nfw_r1 = m_nfw_r1;
+    comp->m_iso_r1 = m_iso_r1;
+    comp->psi_nfw_r1 = psi_nfw_r1;
+    comp->psi_iso_r1 = psi_iso_r1;
 }
 
-static inline void get_extra_nfw_mass(Dwarf* comp, real bound)
+static inline void recalculate_comp_mass(Dwarf* comp, real bound)
 {
+    /* This function recalculates the mass of the component if the bound is changed */
+    /* This is only used for the NFW and Cored profiles right now since the mass goes to infinity */
     /* The mass inputted is taken to be the M200 mass (mass within radius r200).*/
     /* If the sampling boundary goes above or below r200, this function resets the mass of the component.*/
         real m = 0.0;
@@ -726,28 +769,61 @@ static inline void get_extra_nfw_mass(Dwarf* comp, real bound)
 
         if(comp->type == Cored)
         {
-                const real r1 = comp->r1;
-                const real p0 = comp->p0;
-                const real rc = comp->rc;
-                const real ps = comp->ps;
-                const real C1 = 0;
-                const real C3 = C1 + 4 * M_PI * (
-            ps * cube(rs) * (
-                mw_log((1 + r1 / rs)) - r1 / (rs + r1)
-            )
-            - p0 * sqr(rc) * (
-                r1 - rc * mw_atan(r1 / rc)
-            )
-        );
+            const real r1 = comp->r1;
+            const real p0 = comp->p0;
+            const real rc = comp->rc;
+            const real ps = comp->ps;
+            const real rcut = comp->rcut;
 
-                if(r <= r1)
-                        m = 4.0 * M_PI * p0 * sqr(rc) * (r - rc * mw_atan(r / rc)) - C1;
-                else
-                        m = 4.0 * M_PI * ps * cube(rs) * (mw_log( (rs + r) / rs) - r / (rs + r)) - C3;                                                                                                                                          
+            if (rcut != 0.0 && r > rcut)                                                                                         
+            {                                                                                                                    
+                const real pcut = comp->pcut;                                                                                   
+                const real delta = comp->delta;                                                                                 
+                const real rdecay = comp->rdecay;   
+                const real gamma1 = comp->gamma1;     
+                const real m_nfw_r1 = comp->m_nfw_r1;
+                const real m_iso_r1 = comp->m_iso_r1;
+                const real m_nfw_cut = comp->m_nfw_cut;                                                                          
+                m = 4.0 * M_PI * pcut * mw_pow(rcut, -delta) * mw_exp(rcut / rdecay) * mw_pow(rdecay, delta + 3) * (gamma1 - UpperIncompleteGammaFunc(delta + 3, r / rdecay)) + m_nfw_cut + m_iso_r1 - m_nfw_r1;                                           
+            }                                                                                                                    
+            else if (r <= r1)                                                                                                    
+            {                                                                                                                    
+                const real p0 = comp->p0;                                                                                       
+                const real rc = comp->rc;                                                                                       
+                m = 4.0 * M_PI * p0 * sqr(rc) * (r - rc * mw_atan(r / rc));                                                                                 
+            }                                                                                                                    
+            else                                                                                                                 
+            {                                                                                                                    
+                const real ps = comp->ps;                                                                                       
+                const real rs = comp->scaleLength; 
+                const real m_nfw_r1 = comp->m_nfw_r1;
+                const real m_iso_r1 = comp->m_iso_r1;                                                                            
+                m = 4.0 * M_PI * ps * cube(rs) * (mw_log(1.0 + r / rs) - r / (rs + r)) + m_iso_r1 - m_nfw_r1;                                                               
+            }                                                                                                                                                     
         }
-        else
+        else if(comp->type == NFW)
         {
-                m = 4.0 * M_PI * comp->p0 * cube(rs) * (mw_log( (rs + r) / rs) - r / (rs + r));
+            const real p0 = comp->p0;
+            const real rcut = comp->rcut;
+            if (rcut != 0.0) {
+                const real rdecay = comp->rdecay;
+                const real delta = comp->delta;
+                if (r > rcut)
+                {
+                    const real pcut = comp->pcut;
+                    const real gamma1 = comp->gamma1;
+                    const real m_nfw_cut = comp->m_nfw_cut;
+                    m = 4.0 * M_PI * pcut * mw_pow(rcut, -delta) * mw_exp(rcut / rdecay) * mw_pow(rdecay, delta + 3) * (gamma1 - UpperIncompleteGammaFunc(delta + 3, r / rdecay)) +  m_nfw_cut;
+                }
+                else
+                {
+                    m = 4.0 * M_PI * p0 * cube(rs) * (mw_log((rs + r) / rs) - r / (rs + r));
+                }
+            }
+            else
+            {
+                m = 4.0 * M_PI * p0 * cube(rs) * (mw_log((rs + r) / rs) - r / (rs + r));
+            }
         }
     comp->mass = m;
 }
@@ -775,7 +851,7 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
         real * vz = mwCalloc(nbody, sizeof(real));
         real * masses = mwCalloc(nbody, sizeof(real));
 
-
+ 
         mwvector vec = ZERO_VECTOR;
         real rscale_l = comp1->scaleLength; //comp1[1]; /*scale radius of the light component*/
         real rscale_d = comp2->scaleLength; //comp2[1]; /*scale radius of the dark component*/
@@ -791,15 +867,26 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
                 bound1 =  50.0 * (rscale_l + rscale_d);
                 break;
             case NFW:
-                bound1 = 5.0 * comp1->r200;
-                get_extra_nfw_mass(comp1, bound1);
+                if (comp1->rcut != 0.0) {
+                    bound1 = comp1->rcut + 15.0 * comp1->rdecay;
+
+                }
+                else {
+                    bound1 = comp1->r200;
+                }
+                recalculate_comp_mass(comp1, bound1);
                 break;
             case General_Hernquist:
                 bound1 =  50.0 * (rscale_l + rscale_d);
                 break;
             case Cored:
-                bound1 = 5.0 * comp1->r200;
-                get_extra_nfw_mass(comp1, bound1);
+                if (comp1->rcut != 0.0) {
+                    bound1 = comp1->rcut + 15.0 * comp1->rdecay;
+                }
+                else {
+                    bound1 = comp1->r200;
+                }
+                recalculate_comp_mass(comp1, bound1);
                 break;
              default:
                 /* Set unused value to make compiler happy */
@@ -813,15 +900,25 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
                 bound2 =  50.0 * (rscale_l + rscale_d);
                 break;
             case NFW:
-                bound2 = 5.0 * comp2->r200;
-                get_extra_nfw_mass(comp2, bound2);
+                if (comp2->rcut != 0.0) {
+                    bound2 = comp2->rcut + 15.0 * comp2->rdecay;
+                }
+                else {
+                    bound2 = comp2->r200;
+                }
+                recalculate_comp_mass(comp2, bound2);
                 break;
             case General_Hernquist:
                 bound2 =  50.0 * (rscale_l + rscale_d);
                 break;
             case Cored:
-                bound2 = 5.0 * comp2->r200;
-                get_extra_nfw_mass(comp2, bound2);
+                if (comp2->rcut != 0.0) {
+                    bound2 = comp2->rcut + 15.0 * comp2->rdecay;
+                }
+                else {
+                    bound2 = comp2->r200;
+                }
+                recalculate_comp_mass(comp2, bound2);
                 break;
              default:
                 /* Set unused value to make compiler happy */

--- a/nbody/src/nbody_mixeddwarf.c
+++ b/nbody/src/nbody_mixeddwarf.c
@@ -872,7 +872,7 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
 
                 }
                 else {
-                    bound1 = comp1->r200;
+                    bound1 = 5.0 * comp1->r200;
                 }
                 recalculate_comp_mass(comp1, bound1);
                 break;
@@ -884,7 +884,7 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
                     bound1 = comp1->rcut + 15.0 * comp1->rdecay;
                 }
                 else {
-                    bound1 = comp1->r200;
+                    bound1 = 5.0 * comp1->r200;
                 }
                 recalculate_comp_mass(comp1, bound1);
                 break;
@@ -904,7 +904,7 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
                     bound2 = comp2->rcut + 15.0 * comp2->rdecay;
                 }
                 else {
-                    bound2 = comp2->r200;
+                    bound2 = 5.0 * comp2->r200;
                 }
                 recalculate_comp_mass(comp2, bound2);
                 break;
@@ -916,7 +916,7 @@ int nbGenerateMixedDwarfCore(lua_State* luaSt, dsfmt_t* prng, unsigned int nbody
                     bound2 = comp2->rcut + 15.0 * comp2->rdecay;
                 }
                 else {
-                    bound2 = comp2->r200;
+                    bound2 = 5.0 * comp2->r200;
                 }
                 recalculate_comp_mass(comp2, bound2);
                 break;

--- a/nbody/src/nbody_particle_data.c
+++ b/nbody/src/nbody_particle_data.c
@@ -22,12 +22,19 @@ ParticleCollection* create_particle_collection(size_t initial_capacity) {
     // Initialize header fields
     collection->header.simple_output = 1;
     collection->header.has_milkyway = -1;
+    collection->header.has_lmc = -1;
     collection->header.com_x = (real)0.0; 
     collection->header.com_y = (real)0.0; 
     collection->header.com_z = (real)0.0;
     collection->header.cmom_x = (real)0.0; 
     collection->header.cmom_y = (real)0.0; 
     collection->header.cmom_z = (real)0.0;
+    collection->header.lmc_pos_x = (real)0.0;
+    collection->header.lmc_pos_y = (real)0.0;
+    collection->header.lmc_pos_z = (real)0.0;
+    collection->header.lmc_vel_x = (real)0.0;
+    collection->header.lmc_vel_y = (real)0.0;
+    collection->header.lmc_vel_z = (real)0.0;
 
     return collection;
 }
@@ -88,12 +95,32 @@ ParticleCollection* read_particle_file(const char *filename) {
         char *end = start + strlen(start) - 1;
         while (end > start && (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r')) *end-- = '\0';
 
-        // Parse header lines
-        if (strstr(start, "simple_output") == start) {
+        // Parse header lines (order: skip conditions, terminal condition, key=value parsers)
+        if (start[0] == '\0') {
+            /* Empty line - skip (backward compat with blank lines in header) */
+        } else if (start[0] == '#') {
+            if (strstr(start, "ignore") && strstr(start, "id")) {
+                in_header = 0;  /* Column header - end of header */
+            }
+            /* Other # lines - skip (backward compat) */
+        } else if (strstr(start, "simple_output") == start) {
             sscanf(start, "simple_output = %d", &simple_output);
             collection->header.simple_output = simple_output;
         } else if (strstr(start, "hasMilkyway") == start) {
             sscanf(start, "hasMilkyway = %d", &collection->header.has_milkyway);
+        } else if (strstr(start, "hasLMC") == start) {
+            sscanf(start, "hasLMC = %d", &collection->header.has_lmc);
+        } else if (strstr(start, "LMC position") == start) {
+            double lmc_px, lmc_py, lmc_pz, lmc_vx, lmc_vy, lmc_vz;
+            if (sscanf(start, "LMC position = %lf, %lf, %lf,   LMC velocity = %lf, %lf, %lf",
+                       &lmc_px, &lmc_py, &lmc_pz, &lmc_vx, &lmc_vy, &lmc_vz) == 6) {
+                collection->header.lmc_pos_x = (real)lmc_px;
+                collection->header.lmc_pos_y = (real)lmc_py;
+                collection->header.lmc_pos_z = (real)lmc_pz;
+                collection->header.lmc_vel_x = (real)lmc_vx;
+                collection->header.lmc_vel_y = (real)lmc_vy;
+                collection->header.lmc_vel_z = (real)lmc_vz;
+            }
         } else if (strstr(start, "centerOfMass") != NULL) {
             // Handle both combined and separate formats
             double com_x, com_y, com_z, cmom_x, cmom_y, cmom_z;
@@ -131,11 +158,8 @@ ParticleCollection* read_particle_file(const char *filename) {
                     }
                 }
             }
-        } else if (start[0] == '#') {
-            if (strstr(start, "ignore") && strstr(start, "id")) {
-                in_header = 0;
-            }
         } else {
+            /* Unknown line - end header (likely start of data) */
             in_header = 0;
         }
 

--- a/nbody/tests/mixeddwarf_models/plummer_cored.lua
+++ b/nbody/tests/mixeddwarf_models/plummer_cored.lua
@@ -2,20 +2,14 @@
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- Test Environment Lua File 
--- Plummer-Plummer Dwarf model 
--- Total number of bodies are meant to be run with Eric's Parameters 
--- baryon scale radius = 0.181216 kpc
--- radius ratio = 0.182799
--- baryon mass = 1.22251 SMU
--- mass ratio = 0.0126171
--- This gives a ratio of mass per baryon particle/ mass per dark matter particle of 0.1
+-- Plummer-Cored Dwarf model 
 -- Set to null potential to test stability of dwarf (no Milky Way potential or LMC)
 -- Set multiple outputs to true 
 -- Set generate initial output to true 
 -- Softening parameter currently hard coded since the calculation needs to be changed
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- DEAR LUA USER:
 -- This is the developer version of the lua parameter file. 
 -- It gives all the options you can have. 
@@ -34,40 +28,23 @@
 -- MUST still include dwarf parameter list
 -- can control what model to use below
 -- simulation time still taken as the first parameter in the list
+
+-- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
+-- Structural changes to this file also need to be changed in the 
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- especially if the changes are not backwards compatible with the previous format
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
+-- these only get used if only 6 parameters are input from shell script
+-- otherwise they get reset later with the inputs (if 11 given)
+preset_orbit_parameter_l  = 258     -- deg
+preset_orbit_parameter_b  = 45.8    -- deg
+preset_orbit_parameter_r  = 21.5    -- kpc
+preset_orbit_parameter_vx = -185.5  -- kpc/Gyr
+preset_orbit_parameter_vy = 54.7    -- kpc/Gyr
+preset_orbit_parameter_vz = 147.4   -- kpc/Gyr
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-        
-        
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
--- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 40000   -- -- NUMBER OF TOTAL BODIES                                                   -- --
-totalLightBodies      = 10000   -- -- NUMBER OF LIGHT MATTER BODIES                                            -- --
-
-nbodyLikelihoodMethod = "EMD"   -- -- HIST COMPARE METHOD                                                      -- --
-nbodyMinVersion       = "1.93"  -- -- MINIMUM APP VERSION                                                      -- --
-
-run_null_potential    = true   -- -- NULL POTENTIAL SWITCH                                                    -- --
-use_tree_code         = true    -- -- USE TREE CODE NOT EXACT                                                  -- --
-print_reverse_orbit   = false   -- -- PRINT REVERSE ORBIT SWITCH                                               -- --
-print_out_parameters  = false   -- -- PRINT OUT ALL PARAMETERS                                                 -- --
-
-LMC_body              = false    -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                            -- --
-LMC_function          = 1
-LMC_scaleRadius       = 15      -- --  kpc
-LMC_cutoff            = 16.6
-preset_LMC_Mass       = 449865.888  -- -- SMU -- -- only if <12 params are used                                -- --
-LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
-CoulombLogarithm      = 0.470003629 -- -- (ln(1.6)) COULOMB LOGARITHM USED IN DYNAMICAL FRACTION CALCULATION   -- --
-
-SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
-SunVelx               = 10.3      -- -- Sun's x-velocity                                                       -- --
-SunVely               = 229.2     -- -- Sun's y-velocity                                                       -- --
-SunVelz               = 6.9       -- -- Sun's z-velocity                                                       -- --      
-
-UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-
-
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- -- -- -- -- -- -- -- -- MODEL SETTINGS -- -- -- -- -- -- -- -- -- -- -- --
@@ -78,7 +55,139 @@ UseOldSofteningLength = 0         -- -- Uses old softening length formula from v
 -- --       0 - NO DWARF MODEL         -- -- -- -- -- -- -- -- -- -- -- -- --
 ModelComponents   = 2         -- -- TWO COMPONENTS SWITCH   -- -- -- -- -- --
 manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+        
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+
+nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
+nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
+
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
+print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
+print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
+
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
+LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
+LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
+preset_LMC_Mass       = 449865.888  -- -- SMU (used unless specified in arguments)                             -- --
+LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
+CoulombLogarithm      = 15      -- -- ln(r/1.22*CoulombLogarithm) (Patel et al. 2020) COULOMB LOGARITHM USED   -- --
+                                -- -- IN DYNAMICAL FRACTION CALCULATION                                        -- --
+
+SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
+SunVelx               = 10.3      -- -- Sun's x-velocity (kpc/Gyr) (Hogg et al. (2005))                        -- --
+SunVely               = 229.2     -- -- Sun's y-velocity (kpc/Gyr)                                             -- --
+SunVelz               = 6.9       -- -- Sun's z-velocity (kpc/Gyr)                                             -- --
+
+UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+arg = { ... } -- -- TAKING USER INPUT
+assert((#arg == 6 or #arg == 7 or #arg == 8 or #arg == 11 or #arg == 12 or #arg == 13), "Expects either 6, 7, 8, 11, 12, or 13 arguments")
+assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
+argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
+--argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
+prng = DSFMT.create(argSeed)
+-- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
+function round(num, places)
+  local mult = 10.0^(places)
+  return floor(num * mult + 0.5) / mult
+end
+
+-- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
+dec = 9.0
+evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
+time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
+rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
+light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
+mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
+light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
+if (#arg == 7) then
+    if manual_bodies then
+        manual_body_file = arg[7]
+        LMC_Mass = preset_LMC_Mass
+    else 
+        LMC_Mass = round( tonumber(arg[7]), dec )
+    end
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 8) then
+    LMC_Mass = round( tonumber(arg[7]), dec )
+    manual_body_file = arg[8]
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 11) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = preset_LMC_Mass
+elseif (#arg == 12) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    if manual_bodies then
+        manual_body_file = arg[12]
+        LMC_Mass = preset_LMC_Mass
+    else
+        LMC_Mass = round( tonumber(arg[12]), dec )
+    end
+elseif (#arg == 13) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = round( tonumber(arg[12]), dec )
+    manual_body_file = arg[13]
+else
+    -- fallback to preset orbit parameters and LMC mass if not enough args
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+    LMC_Mass = preset_LMC_Mass
+end 
+
+if(ModelComponents == 1) then
+   dwarfMass = mass_l
+   rscale_t  = rscale_l
+   rscale_d  = 1.0
+   mass_d    = 0.0
+else
+   dwarfMass = mass_l / light_mass_ratio
+   rscale_t  = rscale_l / light_r_ratio
+   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
+   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
+end
+
+--component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
+--calculate dwarf-based softening length
+comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.cored{mass = mass_d, scaleLength = rscale_d, r1 = 0.7, rc = 0.6} -- Dwarf Options: plummer, nfw, general_hernquist, cored
 
 
 
@@ -89,9 +198,11 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 
 -- -- -- -- -- -- -- --  OUTPUT SETTINGS  -- -- -- -- -- -- -- -- -- -- -- --
 generateSimpleOutput = true       -- Simple output file includes: x, y, z, vx, vy, vz, mass
--- Full output file includes: x, y, z, l, b, r, lambda, beta, vx, vy, vz, vlos, pmra, pmdec, mass
+-- Full output file includes: x, y, z, l, b, r, vx, vy, vz, mass, vlos, pmra, pmdec, [lambda, beta]
+-- NOTE: Lambda and Beta are optional and will only be included if the histogram parameters are set in makeHistogram()
 
 -- -- -- -- -- -- -- -- -- HISTOGRAM   -- -- -- -- -- -- -- -- -- -- -- -- --
+
 lda_bins        = 50      -- number of bins in lamdba direction
 lda_lower_range = -150    -- lower range for lambda
 lda_upper_range = 150     -- upepr range for lamdba
@@ -119,6 +230,13 @@ use_vlos_comp        = true  -- calculate average los velocity, use in likelihoo
 use_avg_dist         = true  -- calculate average distance, use in likelihood
 use_pm_comp          = true  -- calculate proper motion, use in likelihood
 
+-- if using momentum likelihood, include momentum information in the parameters of the input
+-- histogram (after <histogram> )with the following lines:
+    -- L = {Lx, Ly, Lz} (angular momentum vector)
+    -- LErr = {Err_Lx, Err_Ly, Err_Lz} (uncertainty in angular momentum vector)
+-- These are in units of kpc^2/Gyr (no mass included)
+use_momentum         = true  -- calculate angular momentum, use in likelihood
+
 -- number of additional forward evolutions to do to calibrate the rotation of the bar
 -- numCalibrationRuns + 1 additional forward evolutions will be done
 -- if no bar potential is being used, this variable will be ignored
@@ -131,7 +249,7 @@ numCalibrationRuns = 0
 -- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
 
-useMultiOutputs       = true      -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
 freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
 
 timestep_control      = false       -- -- control number of steps                                                          -- --
@@ -140,23 +258,9 @@ Ntime_steps           = 3000        -- -- number of timesteps to run            
 use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
 max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
 
-generateInitialOutput = true        -- -- save initial dwarf galaxy state to initial.out before evolution                  -- --
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         
-
-
-
-
--- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
--- these only get used if only 6 parameters are input from shell script
--- otherwise they get reset later with the inputs (if 11 given)
-preset_orbit_parameter_l  = 258
-preset_orbit_parameter_b  = 45.8
-preset_orbit_parameter_r  = 21.5
-preset_orbit_parameter_vx = -185.5
-preset_orbit_parameter_vy = 54.7
-preset_orbit_parameter_vz = 147.4
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
         
 -- -- -- -- -- -- -- -- -- CHECK TIMESTEPS -- -- -- -- -- -- -- -- 
 TooManyTimesteps = 0
@@ -168,11 +272,11 @@ function makePotential()
    else
         --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
         return  Potential.create{
-            spherical = Spherical.hernquist{ mass  = 1.52954402e5, scale = 0.7 },
-            disk      = Disk.miyamotoNagai{ mass = 4.45865888e5, scaleLength = 6.5, scaleHeight = 0.26 },
-            disk2     = Disk.none{ mass = 3.0e5 },
-            halo      = Halo.logarithmic{ vhalo = 74.61, scaleLength = 12.0, flattenZ = 1.0 }
-        }--vhalo = 74.61 kpc/gy = 73 km/s
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
    end
 end
 
@@ -205,6 +309,8 @@ function get_timestep()
     end
 
     if ((evolveTime/t > 150000 or t ~= t) and not timestep_control) then
+        -- We could throw an error here, but instead let it run fast and return a poor likelihood
+        -- This way users won't see errors in their workunit logs
         TooManyTimesteps = 1
         t = evolveTime/4.0
     end
@@ -216,8 +322,11 @@ end
 function get_soft_par()
     --softening parameter only calculated based on dwarf,
     --so if manual bodies is turned on the calculated s.p. may be too large
-    sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d, UseOldSofteningLength)
-
+    if (UseOldSofteningLength == 1) then
+        sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d)
+    else
+        sp = calculateEps2Dwarf(comp1, totalLightBodies)
+    end
     if ((manual_bodies or use_max_soft_par) and (sp > max_soft_par^2)) then --dealing with softening parameter squared
         print("Using maximum softening parameter value of " .. tostring(max_soft_par) .. " kpc")
         return max_soft_par^2
@@ -232,7 +341,7 @@ function makeContext()
       timeEvolve  = evolveTime,
       timeBack    = revOrbTime,
       timestep    = get_timestep(),
-      eps2        = 1e-4,
+      eps2        = get_soft_par(), 
       b           = orbit_parameter_b,
       r           = orbit_parameter_r,
       vx          = orbit_parameter_vx,
@@ -252,6 +361,7 @@ function makeContext()
       useVlos       = use_vlos_comp,
       useDist       = use_avg_dist,
       usePropMot    = use_pm_comp,
+      useMomentum   = use_momentum,
       Nstep_control = timestep_control,
       Ntsteps       = Ntime_steps,
       BetaSigma     = SigmaCutoff,
@@ -287,7 +397,9 @@ function makeBodies(ctx, potential)
   local firstModel
   local finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity
     if TooManyTimesteps == 1 then
+        -- Setting bodies to 1 ensures worst case likelihood
         totalBodies = 1
+        totalLightBodies = 1
     end
 
     if(run_null_potential == true and manual_bodies == true) then
@@ -302,10 +414,10 @@ function makeBodies(ctx, potential)
 	            potential   = potential,
 	            position    = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
 	            velocity    = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
-	            LMCposition = Vector.create(-1.1, -41.1, -27.9),
-	            LMCvelocity = Vector.create(-57, -226, 221),
-		            LMCfunction = LMC_fucntion,
-                    LMCmass     = LMC_mass,
+	            LMCposition = Vector.create(-0.52, -40.8, -26.5),
+	            LMCvelocity = Vector.create(-58.2, -231, 226),
+		            LMCfunction = LMC_function,
+                    LMCmass     = LMC_Mass,
                     LMCscale    = LMC_scaleRadius,
 		            LMCscale2   = LMC_cutoff,
                     LMCDynaFric = LMC_DynamicalFriction,
@@ -339,12 +451,8 @@ function makeBodies(ctx, potential)
         print('Printing reverse orbit')
     end
 
+    if(ModelComponents == 2) then         
 
-    if(ModelComponents == 2) then 
-        -- Create components
-        local comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        local comp2 = Dwarf.cored{mass = mass_d, scaleLength = rscale_d, r1 = 0.2, rc = 0.1} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        
         firstModel = predefinedModels.mixeddwarf{
             nbody         = totalBodies,
             nbody_baryon  = totalLightBodies,
@@ -356,21 +464,15 @@ function makeBodies(ctx, potential)
             ignore        = true
         }
         
-        -- Store components in the model's table (needed for stability test)
-        firstModel.components = {
-            comp1 = comp1,
-            comp2 = comp2,
-        }
-        
     elseif(ModelComponents == 1) then
-        firstModel = predefinedModels.plummer{  -- Dwarf Options: plummer, nfw, hernq, isotropic
+        firstModel = predefinedModels.plummer{ 
             nbody       = totalBodies,
-            prng        = prng,
-            position    = finalPosition,
-            velocity    = finalVelocity,
             mass        = mass_l,
             scaleRadius = rscale_l,
-            ignore      = false
+            position    = finalPosition,
+            velocity    = finalVelocity,
+            ignore      = false,
+            prng        = prng
         }
   
     end
@@ -408,66 +510,18 @@ function makeHistogram()
      
      betaStart = bta_lower_range,
      betaEnd   = bta_upper_range,
-     betaBins  = bta_bins
+     betaBins  = bta_bins,
+
+     -- Optional params
+     L = {0.0, 0.0, 0.0}, --If any L components are nonzero, will use this L and LErr for momentum likelihood
+     LErr = {0.0, 0.0, 0.0}, --This will overwrite any momentum values passed in through histogram. Input these as lua tables
+
+     nRange = 0, --If non-zero, will use EMDRange values below. Overwrites values given in input histogram
+     EMDRange = {} --Make sure this has an even number of elements and matches nRange. Input as a lua table
 }
 end
 
 
-arg = { ... } -- -- TAKING USER INPUT
-assert((#arg == 6 or #arg == 7 or #arg == 12 or #arg == 13), "Expects either 6, 7, 12, or 13 arguments, and optional manual body list")
-assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
-argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
---argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
-prng = DSFMT.create(argSeed)
-
--- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
-function round(num, places)
-  local mult = 10.0^(places)
-  return floor(num * mult + 0.5) / mult
-end
-
--- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
-dec = 9.0
-evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
-time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
-rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
-light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
-mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
-light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
-if (#arg >= 7) then
-    if (#arg >= 12) then
-    orbit_parameter_l   = round( tonumber(arg[7]), dec )
-    orbit_parameter_b   = round( tonumber(arg[8]), dec )
-    orbit_parameter_r   = round( tonumber(arg[9]), dec )
-    orbit_parameter_vx  = round( tonumber(arg[10]), dec )
-    orbit_parameter_vy  = round( tonumber(arg[11]), dec )
-    orbit_parameter_vz  = round( tonumber(arg[12]), dec )
-    if (#arg >= 13) then
-        LMC_Mass = round( tonumber(arg[13]), dec )
-    else
-        LMC_Mass = preset_LMC_Mass
-        end
-        manual_body_file = arg[15]
-    else
-        orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    LMC_Mass = round( tonumber(arg[7]), dec )
-    manual_body_file = arg[7] -- File with Individual Particles (.out file)
-    end
-else
-    LMC_Mass = preset_LMC_Mass
-    orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    manual_body_file = arg[8]
-end
 
 -- -- -- -- -- -- -- -- -- DWARF PARAMETERS   -- -- -- -- -- -- -- --
 revOrbTime = evolveTime / time_ratio
@@ -479,17 +533,6 @@ else
 end
 
 
-if(ModelComponents == 1) then
-   dwarfMass = mass_l
-   rscale_t  = rscale_l
-   rscale_d  = 1.0
-   mass_d    = 0.0
-else
-   dwarfMass = mass_l / light_mass_ratio
-   rscale_t  = rscale_l / light_r_ratio
-   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
-   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
-end
    
 
 if(manual_bodies and manual_body_file == nil) then 

--- a/nbody/tests/mixeddwarf_models/plummer_cutoff_cored.lua
+++ b/nbody/tests/mixeddwarf_models/plummer_cutoff_cored.lua
@@ -1,0 +1,561 @@
+-- /* Copyright (c) 2016-2018 Siddhartha Shelton */
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- Test Environment Lua File 
+-- Plummer-Cored Dwarf model 
+-- Set to null potential to test stability of dwarf (no Milky Way potential or LMC)
+-- Set multiple outputs to true 
+-- Set generate initial output to true 
+-- Softening parameter currently hard coded since the calculation needs to be changed
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- DEAR LUA USER:
+-- This is the developer version of the lua parameter file. 
+-- It gives all the options you can have. 
+-- Many of these the client will not need.
+
+-- NOTE --
+-- to fully utilize this lua, need to compile with -DNBODY_DEV_OPTIONS=ON
+-- if you are using single component plummer model, it will take the baryonic
+-- matter component parameters. meaning you input should look like
+-- ft, time_ratio, rscale_baryon, radius_ratio, baryon mass, mass ratio
+-- typical parameters: 4.0, 1.0, 0.2, 0.2, 12, 0.2 (52.5, 28.6, -156, 79, 107)
+-- 222288.47 solar masses = 1 Structure Mass Unit (SMU)
+
+-- available option: using a user inputted list of bodies. Sent in as an 
+-- optional arguement after dwarf parameter list
+-- MUST still include dwarf parameter list
+-- can control what model to use below
+-- simulation time still taken as the first parameter in the list
+
+-- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
+-- Structural changes to this file also need to be changed in the 
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- especially if the changes are not backwards compatible with the previous format
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
+-- these only get used if only 6 parameters are input from shell script
+-- otherwise they get reset later with the inputs (if 11 given)
+preset_orbit_parameter_l  = 258     -- deg
+preset_orbit_parameter_b  = 45.8    -- deg
+preset_orbit_parameter_r  = 21.5    -- kpc
+preset_orbit_parameter_vx = -185.5  -- kpc/Gyr
+preset_orbit_parameter_vy = 54.7    -- kpc/Gyr
+preset_orbit_parameter_vz = 147.4   -- kpc/Gyr
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- MODEL SETTINGS -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- --       ModelComponent Options:    -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- --       2 - TWO COMPONENT MODEL    -- -- -- -- -- -- -- -- -- -- -- -- --
+-- --       1 - SINGLE COMPONENT MODEL  -- -- -- - -- -- -- -- -- -- -- -- -- 
+-- --       0 - NO DWARF MODEL         -- -- -- -- -- -- -- -- -- -- -- -- --
+ModelComponents   = 2         -- -- TWO COMPONENTS SWITCH   -- -- -- -- -- --
+manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+        
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+
+nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
+nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
+
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
+print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
+print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
+
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
+LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
+LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
+preset_LMC_Mass       = 449865.888  -- -- SMU (used unless specified in arguments)                             -- --
+LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
+CoulombLogarithm      = 15      -- -- ln(r/1.22*CoulombLogarithm) (Patel et al. 2020) COULOMB LOGARITHM USED   -- --
+                                -- -- IN DYNAMICAL FRACTION CALCULATION                                        -- --
+
+SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
+SunVelx               = 10.3      -- -- Sun's x-velocity (kpc/Gyr) (Hogg et al. (2005))                        -- --
+SunVely               = 229.2     -- -- Sun's y-velocity (kpc/Gyr)                                             -- --
+SunVelz               = 6.9       -- -- Sun's z-velocity (kpc/Gyr)                                             -- --
+
+UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+arg = { ... } -- -- TAKING USER INPUT
+assert((#arg == 6 or #arg == 7 or #arg == 8 or #arg == 11 or #arg == 12 or #arg == 13), "Expects either 6, 7, 8, 11, 12, or 13 arguments")
+assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
+argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
+--argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
+prng = DSFMT.create(argSeed)
+-- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
+function round(num, places)
+  local mult = 10.0^(places)
+  return floor(num * mult + 0.5) / mult
+end
+
+-- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
+dec = 9.0
+evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
+time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
+rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
+light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
+mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
+light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
+if (#arg == 7) then
+    if manual_bodies then
+        manual_body_file = arg[7]
+        LMC_Mass = preset_LMC_Mass
+    else 
+        LMC_Mass = round( tonumber(arg[7]), dec )
+    end
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 8) then
+    LMC_Mass = round( tonumber(arg[7]), dec )
+    manual_body_file = arg[8]
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 11) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = preset_LMC_Mass
+elseif (#arg == 12) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    if manual_bodies then
+        manual_body_file = arg[12]
+        LMC_Mass = preset_LMC_Mass
+    else
+        LMC_Mass = round( tonumber(arg[12]), dec )
+    end
+elseif (#arg == 13) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = round( tonumber(arg[12]), dec )
+    manual_body_file = arg[13]
+else
+    -- fallback to preset orbit parameters and LMC mass if not enough args
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+    LMC_Mass = preset_LMC_Mass
+end 
+
+if(ModelComponents == 1) then
+   dwarfMass = mass_l
+   rscale_t  = rscale_l
+   rscale_d  = 1.0
+   mass_d    = 0.0
+else
+   dwarfMass = mass_l / light_mass_ratio
+   rscale_t  = rscale_l / light_r_ratio
+   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
+   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
+end
+
+--component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
+--calculate dwarf-based softening length
+comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.cored{mass = mass_d, scaleLength = rscale_d, r1 = 0.7, rc = 0.6, rcut = 4.5} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+
+
+
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- PARAMETER SETTINGS   -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- --  OUTPUT SETTINGS  -- -- -- -- -- -- -- -- -- -- -- --
+generateSimpleOutput = true       -- Simple output file includes: x, y, z, vx, vy, vz, mass
+-- Full output file includes: x, y, z, l, b, r, vx, vy, vz, mass, vlos, pmra, pmdec, [lambda, beta]
+-- NOTE: Lambda and Beta are optional and will only be included if the histogram parameters are set in makeHistogram()
+
+-- -- -- -- -- -- -- -- -- HISTOGRAM   -- -- -- -- -- -- -- -- -- -- -- -- --
+
+lda_bins        = 50      -- number of bins in lamdba direction
+lda_lower_range = -150    -- lower range for lambda
+lda_upper_range = 150     -- upepr range for lamdba
+
+bta_bins        = 1       -- number of beta bins. normally use 1 for 1D hist
+bta_lower_range = -15     -- lower range for beta
+bta_upper_range = 15      -- upper range for beta
+
+SigmaCutoff          = 2.5     -- -- sigma cutoff for outlier rejection DO NOT CHANGE -- --
+SigmaIter            = 6       -- -- number of times to apply outlier rejection DO NOT CHANGE -- --
+Correction           = 1.111   -- -- correction for outlier rejection   DO NOT CHANGE -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+
+-- -- -- -- -- -- -- -- -- AlGORITHM OPTIONS -- -- -- -- -- -- -- --
+use_best_likelihood  = false    -- use the best likelihood return code (ONLY SET TO TRUE FOR RUN-COMPARE)
+best_like_start      = 0.98    -- what percent of sim to start
+
+use_beta_disps       = true    -- use beta dispersions in likelihood
+use_vel_disps        = false    -- use velocity dispersions in likelihood
+
+-- if one of these is true, will get output for all 3 of the new histograms
+-- if not computing likelihood scores, still need one of these to be true if want them computed/output
+use_beta_comp        = true  -- calculate average beta, use in likelihood
+use_vlos_comp        = true  -- calculate average los velocity, use in likelihood
+use_avg_dist         = true  -- calculate average distance, use in likelihood
+use_pm_comp          = true  -- calculate proper motion, use in likelihood
+
+-- if using momentum likelihood, include momentum information in the parameters of the input
+-- histogram (after <histogram> )with the following lines:
+    -- L = {Lx, Ly, Lz} (angular momentum vector)
+    -- LErr = {Err_Lx, Err_Ly, Err_Lz} (uncertainty in angular momentum vector)
+-- These are in units of kpc^2/Gyr (no mass included)
+use_momentum         = true  -- calculate angular momentum, use in likelihood
+
+-- number of additional forward evolutions to do to calibrate the rotation of the bar
+-- numCalibrationRuns + 1 additional forward evolutions will be done
+-- if no bar potential is being used, this variable will be ignored
+numCalibrationRuns = 0
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- ADVANCED DEVELOPER OPTIONS -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
+
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
+
+timestep_control      = false       -- -- control number of steps                                                          -- --
+Ntime_steps           = 3000        -- -- number of timesteps to run                                                       -- --
+
+use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
+max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
+
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        
+        
+-- -- -- -- -- -- -- -- -- CHECK TIMESTEPS -- -- -- -- -- -- -- -- 
+TooManyTimesteps = 0
+        
+function makePotential()
+   if(run_null_potential == true) then
+       print("running in null potential")
+       return nil
+   else
+        --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
+        return  Potential.create{
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
+   end
+end
+
+function get_timestep()
+    if(timestep_control) then
+        t = (evolveTime) / (Ntime_steps)
+    elseif(ModelComponents == 2) then
+
+        --Mass of a single dark matter sphere enclosed within light rscale
+        mass_enc_d = mass_d * (rscale_l)^3 * ( (rscale_l)^2 + (rscale_d)^2  )^(-3.0/2.0)
+
+        --Mass of a single light matter sphere enclosed within dark rscale
+        mass_enc_l = mass_l * (rscale_d)^3 * ( (rscale_l)^2 + (rscale_d)^2  )^(-3.0/2.0)
+
+        s1 = (rscale_l)^3 / (mass_enc_d + mass_l)
+        s2 = (rscale_d)^3 / (mass_enc_l + mass_d)
+        
+        --return the smaller time step
+        if(s1 < s2) then
+            s = s1
+        else
+            s = s2
+        end
+        
+        -- I did it this way so there was only one place to change the time step. 
+        t = (1.0 / 100.0) * ( pi_4_3 * s)^(1.0/2.0)
+        
+    else 
+        t = sqr(1.0 / 10.0) * sqrt((pi_4_3 * cube(rscale_l)) / (mass_l))
+    end
+
+    if ((evolveTime/t > 150000 or t ~= t) and not timestep_control) then
+        -- We could throw an error here, but instead let it run fast and return a poor likelihood
+        -- This way users won't see errors in their workunit logs
+        TooManyTimesteps = 1
+        t = evolveTime/4.0
+    end
+
+    return t
+end
+
+
+function get_soft_par()
+    --softening parameter only calculated based on dwarf,
+    --so if manual bodies is turned on the calculated s.p. may be too large
+    if (UseOldSofteningLength == 1) then
+        sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d)
+    else
+        sp = calculateEps2Dwarf(comp1, totalLightBodies)
+    end
+    if ((manual_bodies or use_max_soft_par) and (sp > max_soft_par^2)) then --dealing with softening parameter squared
+        print("Using maximum softening parameter value of " .. tostring(max_soft_par) .. " kpc")
+        return max_soft_par^2
+    else
+        return sp
+    end
+end
+
+
+function makeContext()
+   return NBodyCtx.create{
+      timeEvolve  = evolveTime,
+      timeBack    = revOrbTime,
+      timestep    = get_timestep(),
+      eps2        = 1e-4, 
+      b           = orbit_parameter_b,
+      r           = orbit_parameter_r,
+      vx          = orbit_parameter_vx,
+      vy          = orbit_parameter_vy,
+      vz          = orbit_parameter_vz,
+      sunGCDist   = SunGCDist,
+      sunVelx     = SunVelx,
+      sunVely     = SunVely,
+      sunVelz     = SunVelz,
+      criterion   = criterion,
+      useQuad     = true,
+      useBestLike   = use_best_likelihood,
+      BestLikeStart = eff_best_like_start,
+      useVelDisp    = use_vel_disps,
+      useBetaDisp   = use_beta_disps,
+      useBetaComp   = use_beta_comp,
+      useVlos       = use_vlos_comp,
+      useDist       = use_avg_dist,
+      usePropMot    = use_pm_comp,
+      useMomentum   = use_momentum,
+      Nstep_control = timestep_control,
+      Ntsteps       = Ntime_steps,
+      BetaSigma     = SigmaCutoff,
+      VelSigma      = SigmaCutoff,
+      DistSigma     = SigmaCutoff,
+      PMSigma       = SigmaCutoff,
+      MomentumSigma = SigmaCutoff,
+      IterMax       = SigmaIter,
+      BetaCorrect   = Correction,
+      VelCorrect    = Correction,
+      DistCorrect   = Correction,
+      PMCorrect     = Correction,
+      MomentumCorrect = Correction,
+      SimpleOutput  = generateSimpleOutput,
+      MultiOutput   = useMultiOutputs,
+      OutputFreq    = freqOfOutputs,
+      InitialOutput = generateInitialOutput,
+      theta         = 1.0,
+      LMC           = LMC_body,
+      LMCfunction   = LMC_function,
+      LMCmass       = LMC_Mass,
+      LMCscale      = LMC_scaleRadius,
+      LMCscale2     = LMC_cutoff,
+      LMCDynaFric   = LMC_DynamicalFriction,
+      coulomb_log   = CoulombLogarithm,
+      calibrationRuns = numCalibrationRuns
+   }
+end
+
+
+
+function makeBodies(ctx, potential)
+  local firstModel
+  local finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity
+    if TooManyTimesteps == 1 then
+        -- Setting bodies to 1 ensures worst case likelihood
+        totalBodies = 1
+        totalLightBodies = 1
+    end
+
+    if(run_null_potential == true and manual_bodies == true) then
+        finalPosition = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r))
+        finalVelocity = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz)
+    elseif(run_null_potential == true) then
+        print("placing dwarf at origin")
+        finalPosition, finalVelocity = Vector.create(0, 0, 0), Vector.create(0, 0, 0)
+    else 
+    	if (LMC_body) then
+    		finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity = reverseOrbit_LMC{
+	            potential   = potential,
+	            position    = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
+	            velocity    = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
+	            LMCposition = Vector.create(-0.52, -40.8, -26.5),
+	            LMCvelocity = Vector.create(-58.2, -231, 226),
+		            LMCfunction = LMC_function,
+                    LMCmass     = LMC_Mass,
+                    LMCscale    = LMC_scaleRadius,
+		            LMCscale2   = LMC_cutoff,
+                    LMCDynaFric = LMC_DynamicalFriction,
+                    coulomb_log = CoulombLogarithm,
+                    ftime       = evolveTime,
+	            tstop       = revOrbTime,
+	            dt          = ctx.timestep / 10.0
+	            }
+
+              
+	    else
+	        finalPosition, finalVelocity = reverseOrbit{
+	            potential = potential,
+	            position  = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
+	            velocity  = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
+	            tstop     = revOrbTime,
+	            dt        = ctx.timestep / 10.0
+	            }
+         end
+    end
+    
+    if(print_reverse_orbit == true) then
+        local placeholderPos, placeholderVel = PrintReverseOrbit{
+            potential = potential,
+            position  = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
+            velocity  = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
+            tstop     = .14,
+            tstopf    = .20,
+            dt        = ctx.timestep / 10.0
+        }
+        print('Printing reverse orbit')
+    end
+
+    if(ModelComponents == 2) then         
+
+        firstModel = predefinedModels.mixeddwarf{
+            nbody         = totalBodies,
+            nbody_baryon  = totalLightBodies,
+            prng          = prng,
+            position      = finalPosition,
+            velocity      = finalVelocity,
+            comp1         = comp1,
+            comp2         = comp2,
+            ignore        = true
+        }
+        
+    elseif(ModelComponents == 1) then
+        firstModel = predefinedModels.plummer{ 
+            nbody       = totalBodies,
+            mass        = mass_l,
+            scaleRadius = rscale_l,
+            position    = finalPosition,
+            velocity    = finalVelocity,
+            ignore      = false,
+            prng        = prng
+        }
+  
+    end
+  
+    if(manual_bodies) then
+        manualModel = predefinedModels.manual_bodies{
+        body_file   = manual_body_file,
+    }
+         
+    end
+    
+    if(ModelComponents > 0 and manual_bodies) then 
+        return firstModel, manualModel
+    elseif(ModelComponents == 0 and manual_bodies) then
+        return manualModel
+    elseif(ModelComponents > 0 and not manual_bodies) then
+        return firstModel
+    else    
+        print("Don't you want to simulate something?")
+    end
+    
+end
+
+function makeHistogram()
+    return HistogramParams.create{
+     --Orphan Stream coordinate transformation angles
+     phi = 128.79,
+     theta = 54.39,
+     psi = 90.70,
+     
+     -- ANGULAR RANGE AND NUMBER OF BINS
+     lambdaStart = lda_lower_range,
+     lambdaEnd   = lda_upper_range,
+     lambdaBins  = lda_bins,
+     
+     betaStart = bta_lower_range,
+     betaEnd   = bta_upper_range,
+     betaBins  = bta_bins,
+
+     -- Optional params
+     L = {0.0, 0.0, 0.0}, --If any L components are nonzero, will use this L and LErr for momentum likelihood
+     LErr = {0.0, 0.0, 0.0}, --This will overwrite any momentum values passed in through histogram. Input these as lua tables
+
+     nRange = 0, --If non-zero, will use EMDRange values below. Overwrites values given in input histogram
+     EMDRange = {} --Make sure this has an even number of elements and matches nRange. Input as a lua table
+}
+end
+
+
+
+-- -- -- -- -- -- -- -- -- DWARF PARAMETERS   -- -- -- -- -- -- -- --
+revOrbTime = evolveTime / time_ratio
+if use_best_likelihood then
+    evolveTime = (2.0 - best_like_start) * evolveTime --making it evolve slightly longer
+    eff_best_like_start = best_like_start / (2.0 - best_like_start)
+else
+    eff_best_like_start = best_like_start
+end
+
+
+   
+
+if(manual_bodies and manual_body_file == nil) then 
+    print 'WARNING: No body list given. Manual body input turn off'
+    manual_bodies = false  --optional body list was not included
+elseif(manual_bodies and ModelComponents == 0) then
+    print 'Using user inputted body list only' 
+    print( manual_body_file)
+elseif(manual_bodies and ModelComponents ~= 0) then
+    print 'Using dwarf model and user inputted body list'
+end
+
+
+if(use_tree_code) then
+    criterion = "TreeCode"
+else
+    criterion = "Exact"
+end
+
+if(print_out_parameters) then
+    print('forward time=', evolveTime, '\nreverse time=',  revOrbTime)
+    print('mass_l sim=', mass_l, '\nmass_d sim=', mass_d)
+    print('light mass solar=', mass_l * 222288.47, '\ndark mass solar=', mass_d * 222288.47)
+    print('total mass solar= ', (mass_d + mass_l) * 222288.47)
+    print('rl = ', rscale_l, 'rd = ', rscale_d)
+end

--- a/nbody/tests/mixeddwarf_models/plummer_cutoff_nfw.lua
+++ b/nbody/tests/mixeddwarf_models/plummer_cutoff_nfw.lua
@@ -1,0 +1,561 @@
+-- /* Copyright (c) 2016-2018 Siddhartha Shelton */
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- Test Environment Lua File 
+-- Plummer-NFW Dwarf model 
+-- Set to null potential to test stability of dwarf (no Milky Way potential or LMC)
+-- Set multiple outputs to true 
+-- Set generate initial output to true 
+-- Softening parameter currently hard coded since the calculation needs to be changed
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- DEAR LUA USER:
+-- This is the developer version of the lua parameter file. 
+-- It gives all the options you can have. 
+-- Many of these the client will not need.
+
+-- NOTE --
+-- to fully utilize this lua, need to compile with -DNBODY_DEV_OPTIONS=ON
+-- if you are using single component plummer model, it will take the baryonic
+-- matter component parameters. meaning you input should look like
+-- ft, time_ratio, rscale_baryon, radius_ratio, baryon mass, mass ratio
+-- typical parameters: 4.0, 1.0, 0.2, 0.2, 12, 0.2 (52.5, 28.6, -156, 79, 107)
+-- 222288.47 solar masses = 1 Structure Mass Unit (SMU)
+
+-- available option: using a user inputted list of bodies. Sent in as an 
+-- optional arguement after dwarf parameter list
+-- MUST still include dwarf parameter list
+-- can control what model to use below
+-- simulation time still taken as the first parameter in the list
+
+-- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
+-- Structural changes to this file also need to be changed in the 
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- especially if the changes are not backwards compatible with the previous format
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
+-- these only get used if only 6 parameters are input from shell script
+-- otherwise they get reset later with the inputs (if 11 given)
+preset_orbit_parameter_l  = 258     -- deg
+preset_orbit_parameter_b  = 45.8    -- deg
+preset_orbit_parameter_r  = 21.5    -- kpc
+preset_orbit_parameter_vx = -185.5  -- kpc/Gyr
+preset_orbit_parameter_vy = 54.7    -- kpc/Gyr
+preset_orbit_parameter_vz = 147.4   -- kpc/Gyr
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- MODEL SETTINGS -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- --       ModelComponent Options:    -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- --       2 - TWO COMPONENT MODEL    -- -- -- -- -- -- -- -- -- -- -- -- --
+-- --       1 - SINGLE COMPONENT MODEL  -- -- -- - -- -- -- -- -- -- -- -- -- 
+-- --       0 - NO DWARF MODEL         -- -- -- -- -- -- -- -- -- -- -- -- --
+ModelComponents   = 2         -- -- TWO COMPONENTS SWITCH   -- -- -- -- -- --
+manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+        
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+
+nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
+nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
+
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
+print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
+print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
+
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
+LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
+LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
+preset_LMC_Mass       = 449865.888  -- -- SMU (used unless specified in arguments)                             -- --
+LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
+CoulombLogarithm      = 15      -- -- ln(r/1.22*CoulombLogarithm) (Patel et al. 2020) COULOMB LOGARITHM USED   -- --
+                                -- -- IN DYNAMICAL FRACTION CALCULATION                                        -- --
+
+SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
+SunVelx               = 10.3      -- -- Sun's x-velocity (kpc/Gyr) (Hogg et al. (2005))                        -- --
+SunVely               = 229.2     -- -- Sun's y-velocity (kpc/Gyr)                                             -- --
+SunVelz               = 6.9       -- -- Sun's z-velocity (kpc/Gyr)                                             -- --
+
+UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+arg = { ... } -- -- TAKING USER INPUT
+assert((#arg == 6 or #arg == 7 or #arg == 8 or #arg == 11 or #arg == 12 or #arg == 13), "Expects either 6, 7, 8, 11, 12, or 13 arguments")
+assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
+argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
+--argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
+prng = DSFMT.create(argSeed)
+-- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
+function round(num, places)
+  local mult = 10.0^(places)
+  return floor(num * mult + 0.5) / mult
+end
+
+-- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
+dec = 9.0
+evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
+time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
+rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
+light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
+mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
+light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
+if (#arg == 7) then
+    if manual_bodies then
+        manual_body_file = arg[7]
+        LMC_Mass = preset_LMC_Mass
+    else 
+        LMC_Mass = round( tonumber(arg[7]), dec )
+    end
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 8) then
+    LMC_Mass = round( tonumber(arg[7]), dec )
+    manual_body_file = arg[8]
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 11) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = preset_LMC_Mass
+elseif (#arg == 12) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    if manual_bodies then
+        manual_body_file = arg[12]
+        LMC_Mass = preset_LMC_Mass
+    else
+        LMC_Mass = round( tonumber(arg[12]), dec )
+    end
+elseif (#arg == 13) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = round( tonumber(arg[12]), dec )
+    manual_body_file = arg[13]
+else
+    -- fallback to preset orbit parameters and LMC mass if not enough args
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+    LMC_Mass = preset_LMC_Mass
+end 
+
+if(ModelComponents == 1) then
+   dwarfMass = mass_l
+   rscale_t  = rscale_l
+   rscale_d  = 1.0
+   mass_d    = 0.0
+else
+   dwarfMass = mass_l / light_mass_ratio
+   rscale_t  = rscale_l / light_r_ratio
+   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
+   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
+end
+
+--component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
+--calculate dwarf-based softening length
+comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.nfw{mass = mass_d, scaleLength = rscale_d, rcut = 4.5} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+
+
+
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- PARAMETER SETTINGS   -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- --  OUTPUT SETTINGS  -- -- -- -- -- -- -- -- -- -- -- --
+generateSimpleOutput = true       -- Simple output file includes: x, y, z, vx, vy, vz, mass
+-- Full output file includes: x, y, z, l, b, r, vx, vy, vz, mass, vlos, pmra, pmdec, [lambda, beta]
+-- NOTE: Lambda and Beta are optional and will only be included if the histogram parameters are set in makeHistogram()
+
+-- -- -- -- -- -- -- -- -- HISTOGRAM   -- -- -- -- -- -- -- -- -- -- -- -- --
+
+lda_bins        = 50      -- number of bins in lamdba direction
+lda_lower_range = -150    -- lower range for lambda
+lda_upper_range = 150     -- upepr range for lamdba
+
+bta_bins        = 1       -- number of beta bins. normally use 1 for 1D hist
+bta_lower_range = -15     -- lower range for beta
+bta_upper_range = 15      -- upper range for beta
+
+SigmaCutoff          = 2.5     -- -- sigma cutoff for outlier rejection DO NOT CHANGE -- --
+SigmaIter            = 6       -- -- number of times to apply outlier rejection DO NOT CHANGE -- --
+Correction           = 1.111   -- -- correction for outlier rejection   DO NOT CHANGE -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+
+-- -- -- -- -- -- -- -- -- AlGORITHM OPTIONS -- -- -- -- -- -- -- --
+use_best_likelihood  = false    -- use the best likelihood return code (ONLY SET TO TRUE FOR RUN-COMPARE)
+best_like_start      = 0.98    -- what percent of sim to start
+
+use_beta_disps       = true    -- use beta dispersions in likelihood
+use_vel_disps        = false    -- use velocity dispersions in likelihood
+
+-- if one of these is true, will get output for all 3 of the new histograms
+-- if not computing likelihood scores, still need one of these to be true if want them computed/output
+use_beta_comp        = true  -- calculate average beta, use in likelihood
+use_vlos_comp        = true  -- calculate average los velocity, use in likelihood
+use_avg_dist         = true  -- calculate average distance, use in likelihood
+use_pm_comp          = true  -- calculate proper motion, use in likelihood
+
+-- if using momentum likelihood, include momentum information in the parameters of the input
+-- histogram (after <histogram> )with the following lines:
+    -- L = {Lx, Ly, Lz} (angular momentum vector)
+    -- LErr = {Err_Lx, Err_Ly, Err_Lz} (uncertainty in angular momentum vector)
+-- These are in units of kpc^2/Gyr (no mass included)
+use_momentum         = true  -- calculate angular momentum, use in likelihood
+
+-- number of additional forward evolutions to do to calibrate the rotation of the bar
+-- numCalibrationRuns + 1 additional forward evolutions will be done
+-- if no bar potential is being used, this variable will be ignored
+numCalibrationRuns = 0
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- ADVANCED DEVELOPER OPTIONS -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
+
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
+
+timestep_control      = false       -- -- control number of steps                                                          -- --
+Ntime_steps           = 3000        -- -- number of timesteps to run                                                       -- --
+
+use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
+max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
+
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        
+        
+-- -- -- -- -- -- -- -- -- CHECK TIMESTEPS -- -- -- -- -- -- -- -- 
+TooManyTimesteps = 0
+        
+function makePotential()
+   if(run_null_potential == true) then
+       print("running in null potential")
+       return nil
+   else
+        --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
+        return  Potential.create{
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
+   end
+end
+
+function get_timestep()
+    if(timestep_control) then
+        t = (evolveTime) / (Ntime_steps)
+    elseif(ModelComponents == 2) then
+
+        --Mass of a single dark matter sphere enclosed within light rscale
+        mass_enc_d = mass_d * (rscale_l)^3 * ( (rscale_l)^2 + (rscale_d)^2  )^(-3.0/2.0)
+
+        --Mass of a single light matter sphere enclosed within dark rscale
+        mass_enc_l = mass_l * (rscale_d)^3 * ( (rscale_l)^2 + (rscale_d)^2  )^(-3.0/2.0)
+
+        s1 = (rscale_l)^3 / (mass_enc_d + mass_l)
+        s2 = (rscale_d)^3 / (mass_enc_l + mass_d)
+        
+        --return the smaller time step
+        if(s1 < s2) then
+            s = s1
+        else
+            s = s2
+        end
+        
+        -- I did it this way so there was only one place to change the time step. 
+        t = (1.0 / 100.0) * ( pi_4_3 * s)^(1.0/2.0)
+        
+    else 
+        t = sqr(1.0 / 10.0) * sqrt((pi_4_3 * cube(rscale_l)) / (mass_l))
+    end
+
+    if ((evolveTime/t > 150000 or t ~= t) and not timestep_control) then
+        -- We could throw an error here, but instead let it run fast and return a poor likelihood
+        -- This way users won't see errors in their workunit logs
+        TooManyTimesteps = 1
+        t = evolveTime/4.0
+    end
+
+    return t
+end
+
+
+function get_soft_par()
+    --softening parameter only calculated based on dwarf,
+    --so if manual bodies is turned on the calculated s.p. may be too large
+    if (UseOldSofteningLength == 1) then
+        sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d)
+    else
+        sp = calculateEps2Dwarf(comp1, totalLightBodies)
+    end
+    if ((manual_bodies or use_max_soft_par) and (sp > max_soft_par^2)) then --dealing with softening parameter squared
+        print("Using maximum softening parameter value of " .. tostring(max_soft_par) .. " kpc")
+        return max_soft_par^2
+    else
+        return sp
+    end
+end
+
+
+function makeContext()
+   return NBodyCtx.create{
+      timeEvolve  = evolveTime,
+      timeBack    = revOrbTime,
+      timestep    = get_timestep(),
+      eps2        = get_soft_par(), 
+      b           = orbit_parameter_b,
+      r           = orbit_parameter_r,
+      vx          = orbit_parameter_vx,
+      vy          = orbit_parameter_vy,
+      vz          = orbit_parameter_vz,
+      sunGCDist   = SunGCDist,
+      sunVelx     = SunVelx,
+      sunVely     = SunVely,
+      sunVelz     = SunVelz,
+      criterion   = criterion,
+      useQuad     = true,
+      useBestLike   = use_best_likelihood,
+      BestLikeStart = eff_best_like_start,
+      useVelDisp    = use_vel_disps,
+      useBetaDisp   = use_beta_disps,
+      useBetaComp   = use_beta_comp,
+      useVlos       = use_vlos_comp,
+      useDist       = use_avg_dist,
+      usePropMot    = use_pm_comp,
+      useMomentum   = use_momentum,
+      Nstep_control = timestep_control,
+      Ntsteps       = Ntime_steps,
+      BetaSigma     = SigmaCutoff,
+      VelSigma      = SigmaCutoff,
+      DistSigma     = SigmaCutoff,
+      PMSigma       = SigmaCutoff,
+      MomentumSigma = SigmaCutoff,
+      IterMax       = SigmaIter,
+      BetaCorrect   = Correction,
+      VelCorrect    = Correction,
+      DistCorrect   = Correction,
+      PMCorrect     = Correction,
+      MomentumCorrect = Correction,
+      SimpleOutput  = generateSimpleOutput,
+      MultiOutput   = useMultiOutputs,
+      OutputFreq    = freqOfOutputs,
+      InitialOutput = generateInitialOutput,
+      theta         = 1.0,
+      LMC           = LMC_body,
+      LMCfunction   = LMC_function,
+      LMCmass       = LMC_Mass,
+      LMCscale      = LMC_scaleRadius,
+      LMCscale2     = LMC_cutoff,
+      LMCDynaFric   = LMC_DynamicalFriction,
+      coulomb_log   = CoulombLogarithm,
+      calibrationRuns = numCalibrationRuns
+   }
+end
+
+
+
+function makeBodies(ctx, potential)
+  local firstModel
+  local finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity
+    if TooManyTimesteps == 1 then
+        -- Setting bodies to 1 ensures worst case likelihood
+        totalBodies = 1
+        totalLightBodies = 1
+    end
+
+    if(run_null_potential == true and manual_bodies == true) then
+        finalPosition = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r))
+        finalVelocity = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz)
+    elseif(run_null_potential == true) then
+        print("placing dwarf at origin")
+        finalPosition, finalVelocity = Vector.create(0, 0, 0), Vector.create(0, 0, 0)
+    else 
+    	if (LMC_body) then
+    		finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity = reverseOrbit_LMC{
+	            potential   = potential,
+	            position    = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
+	            velocity    = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
+	            LMCposition = Vector.create(-0.52, -40.8, -26.5),
+	            LMCvelocity = Vector.create(-58.2, -231, 226),
+		            LMCfunction = LMC_function,
+                    LMCmass     = LMC_Mass,
+                    LMCscale    = LMC_scaleRadius,
+		            LMCscale2   = LMC_cutoff,
+                    LMCDynaFric = LMC_DynamicalFriction,
+                    coulomb_log = CoulombLogarithm,
+                    ftime       = evolveTime,
+	            tstop       = revOrbTime,
+	            dt          = ctx.timestep / 10.0
+	            }
+
+              
+	    else
+	        finalPosition, finalVelocity = reverseOrbit{
+	            potential = potential,
+	            position  = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
+	            velocity  = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
+	            tstop     = revOrbTime,
+	            dt        = ctx.timestep / 10.0
+	            }
+         end
+    end
+    
+    if(print_reverse_orbit == true) then
+        local placeholderPos, placeholderVel = PrintReverseOrbit{
+            potential = potential,
+            position  = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
+            velocity  = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
+            tstop     = .14,
+            tstopf    = .20,
+            dt        = ctx.timestep / 10.0
+        }
+        print('Printing reverse orbit')
+    end
+
+    if(ModelComponents == 2) then         
+
+        firstModel = predefinedModels.mixeddwarf{
+            nbody         = totalBodies,
+            nbody_baryon  = totalLightBodies,
+            prng          = prng,
+            position      = finalPosition,
+            velocity      = finalVelocity,
+            comp1         = comp1,
+            comp2         = comp2,
+            ignore        = true
+        }
+        
+    elseif(ModelComponents == 1) then
+        firstModel = predefinedModels.plummer{ 
+            nbody       = totalBodies,
+            mass        = mass_l,
+            scaleRadius = rscale_l,
+            position    = finalPosition,
+            velocity    = finalVelocity,
+            ignore      = false,
+            prng        = prng
+        }
+  
+    end
+  
+    if(manual_bodies) then
+        manualModel = predefinedModels.manual_bodies{
+        body_file   = manual_body_file,
+    }
+         
+    end
+    
+    if(ModelComponents > 0 and manual_bodies) then 
+        return firstModel, manualModel
+    elseif(ModelComponents == 0 and manual_bodies) then
+        return manualModel
+    elseif(ModelComponents > 0 and not manual_bodies) then
+        return firstModel
+    else    
+        print("Don't you want to simulate something?")
+    end
+    
+end
+
+function makeHistogram()
+    return HistogramParams.create{
+     --Orphan Stream coordinate transformation angles
+     phi = 128.79,
+     theta = 54.39,
+     psi = 90.70,
+     
+     -- ANGULAR RANGE AND NUMBER OF BINS
+     lambdaStart = lda_lower_range,
+     lambdaEnd   = lda_upper_range,
+     lambdaBins  = lda_bins,
+     
+     betaStart = bta_lower_range,
+     betaEnd   = bta_upper_range,
+     betaBins  = bta_bins,
+
+     -- Optional params
+     L = {0.0, 0.0, 0.0}, --If any L components are nonzero, will use this L and LErr for momentum likelihood
+     LErr = {0.0, 0.0, 0.0}, --This will overwrite any momentum values passed in through histogram. Input these as lua tables
+
+     nRange = 0, --If non-zero, will use EMDRange values below. Overwrites values given in input histogram
+     EMDRange = {} --Make sure this has an even number of elements and matches nRange. Input as a lua table
+}
+end
+
+
+
+-- -- -- -- -- -- -- -- -- DWARF PARAMETERS   -- -- -- -- -- -- -- --
+revOrbTime = evolveTime / time_ratio
+if use_best_likelihood then
+    evolveTime = (2.0 - best_like_start) * evolveTime --making it evolve slightly longer
+    eff_best_like_start = best_like_start / (2.0 - best_like_start)
+else
+    eff_best_like_start = best_like_start
+end
+
+
+   
+
+if(manual_bodies and manual_body_file == nil) then 
+    print 'WARNING: No body list given. Manual body input turn off'
+    manual_bodies = false  --optional body list was not included
+elseif(manual_bodies and ModelComponents == 0) then
+    print 'Using user inputted body list only' 
+    print( manual_body_file)
+elseif(manual_bodies and ModelComponents ~= 0) then
+    print 'Using dwarf model and user inputted body list'
+end
+
+
+if(use_tree_code) then
+    criterion = "TreeCode"
+else
+    criterion = "Exact"
+end
+
+if(print_out_parameters) then
+    print('forward time=', evolveTime, '\nreverse time=',  revOrbTime)
+    print('mass_l sim=', mass_l, '\nmass_d sim=', mass_d)
+    print('light mass solar=', mass_l * 222288.47, '\ndark mass solar=', mass_d * 222288.47)
+    print('total mass solar= ', (mass_d + mass_l) * 222288.47)
+    print('rl = ', rscale_l, 'rd = ', rscale_d)
+end

--- a/nbody/tests/mixeddwarf_models/plummer_hernquist.lua
+++ b/nbody/tests/mixeddwarf_models/plummer_hernquist.lua
@@ -2,20 +2,14 @@
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- Test Environment Lua File 
--- Plummer-Plummer Dwarf model 
--- Total number of bodies are meant to be run with Eric's Parameters 
--- baryon scale radius = 0.181216 kpc
--- radius ratio = 0.182799
--- baryon mass = 1.22251 SMU
--- mass ratio = 0.0126171
--- This gives a ratio of mass per baryon particle/ mass per dark matter particle of 0.1
+-- Plummer-Hernquist Dwarf model 
 -- Set to null potential to test stability of dwarf (no Milky Way potential or LMC)
 -- Set multiple outputs to true 
 -- Set generate initial output to true 
 -- Softening parameter currently hard coded since the calculation needs to be changed
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- DEAR LUA USER:
 -- This is the developer version of the lua parameter file. 
 -- It gives all the options you can have. 
@@ -34,40 +28,23 @@
 -- MUST still include dwarf parameter list
 -- can control what model to use below
 -- simulation time still taken as the first parameter in the list
+
+-- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
+-- Structural changes to this file also need to be changed in the 
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- especially if the changes are not backwards compatible with the previous format
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
+-- these only get used if only 6 parameters are input from shell script
+-- otherwise they get reset later with the inputs (if 11 given)
+preset_orbit_parameter_l  = 258     -- deg
+preset_orbit_parameter_b  = 45.8    -- deg
+preset_orbit_parameter_r  = 21.5    -- kpc
+preset_orbit_parameter_vx = -185.5  -- kpc/Gyr
+preset_orbit_parameter_vy = 54.7    -- kpc/Gyr
+preset_orbit_parameter_vz = 147.4   -- kpc/Gyr
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-        
-        
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
--- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 40000   -- -- NUMBER OF TOTAL BODIES                                                   -- --
-totalLightBodies      = 10000   -- -- NUMBER OF LIGHT MATTER BODIES                                            -- --
-
-nbodyLikelihoodMethod = "EMD"   -- -- HIST COMPARE METHOD                                                      -- --
-nbodyMinVersion       = "1.93"  -- -- MINIMUM APP VERSION                                                      -- --
-
-run_null_potential    = true   -- -- NULL POTENTIAL SWITCH                                                    -- --
-use_tree_code         = true    -- -- USE TREE CODE NOT EXACT                                                  -- --
-print_reverse_orbit   = false   -- -- PRINT REVERSE ORBIT SWITCH                                               -- --
-print_out_parameters  = false   -- -- PRINT OUT ALL PARAMETERS                                                 -- --
-
-LMC_body              = false    -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                            -- --
-LMC_function          = 1
-LMC_scaleRadius       = 15      -- --  kpc
-LMC_cutoff            = 16.6
-preset_LMC_Mass       = 449865.888  -- -- SMU -- -- only if <12 params are used                                -- --
-LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
-CoulombLogarithm      = 0.470003629 -- -- (ln(1.6)) COULOMB LOGARITHM USED IN DYNAMICAL FRACTION CALCULATION   -- --
-
-SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
-SunVelx               = 10.3      -- -- Sun's x-velocity                                                       -- --
-SunVely               = 229.2     -- -- Sun's y-velocity                                                       -- --
-SunVelz               = 6.9       -- -- Sun's z-velocity                                                       -- --      
-
-UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-
-
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- -- -- -- -- -- -- -- -- MODEL SETTINGS -- -- -- -- -- -- -- -- -- -- -- --
@@ -78,7 +55,139 @@ UseOldSofteningLength = 0         -- -- Uses old softening length formula from v
 -- --       0 - NO DWARF MODEL         -- -- -- -- -- -- -- -- -- -- -- -- --
 ModelComponents   = 2         -- -- TWO COMPONENTS SWITCH   -- -- -- -- -- --
 manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+        
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+
+nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
+nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
+
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
+print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
+print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
+
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
+LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
+LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
+preset_LMC_Mass       = 449865.888  -- -- SMU (used unless specified in arguments)                             -- --
+LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
+CoulombLogarithm      = 15      -- -- ln(r/1.22*CoulombLogarithm) (Patel et al. 2020) COULOMB LOGARITHM USED   -- --
+                                -- -- IN DYNAMICAL FRACTION CALCULATION                                        -- --
+
+SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
+SunVelx               = 10.3      -- -- Sun's x-velocity (kpc/Gyr) (Hogg et al. (2005))                        -- --
+SunVely               = 229.2     -- -- Sun's y-velocity (kpc/Gyr)                                             -- --
+SunVelz               = 6.9       -- -- Sun's z-velocity (kpc/Gyr)                                             -- --
+
+UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+arg = { ... } -- -- TAKING USER INPUT
+assert((#arg == 6 or #arg == 7 or #arg == 8 or #arg == 11 or #arg == 12 or #arg == 13), "Expects either 6, 7, 8, 11, 12, or 13 arguments")
+assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
+argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
+--argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
+prng = DSFMT.create(argSeed)
+-- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
+function round(num, places)
+  local mult = 10.0^(places)
+  return floor(num * mult + 0.5) / mult
+end
+
+-- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
+dec = 9.0
+evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
+time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
+rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
+light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
+mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
+light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
+if (#arg == 7) then
+    if manual_bodies then
+        manual_body_file = arg[7]
+        LMC_Mass = preset_LMC_Mass
+    else 
+        LMC_Mass = round( tonumber(arg[7]), dec )
+    end
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 8) then
+    LMC_Mass = round( tonumber(arg[7]), dec )
+    manual_body_file = arg[8]
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 11) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = preset_LMC_Mass
+elseif (#arg == 12) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    if manual_bodies then
+        manual_body_file = arg[12]
+        LMC_Mass = preset_LMC_Mass
+    else
+        LMC_Mass = round( tonumber(arg[12]), dec )
+    end
+elseif (#arg == 13) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = round( tonumber(arg[12]), dec )
+    manual_body_file = arg[13]
+else
+    -- fallback to preset orbit parameters and LMC mass if not enough args
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+    LMC_Mass = preset_LMC_Mass
+end 
+
+if(ModelComponents == 1) then
+   dwarfMass = mass_l
+   rscale_t  = rscale_l
+   rscale_d  = 1.0
+   mass_d    = 0.0
+else
+   dwarfMass = mass_l / light_mass_ratio
+   rscale_t  = rscale_l / light_r_ratio
+   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
+   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
+end
+
+--component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
+--calculate dwarf-based softening length
+comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.general_hernquist{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
 
 
 
@@ -89,9 +198,11 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 
 -- -- -- -- -- -- -- --  OUTPUT SETTINGS  -- -- -- -- -- -- -- -- -- -- -- --
 generateSimpleOutput = true       -- Simple output file includes: x, y, z, vx, vy, vz, mass
--- Full output file includes: x, y, z, l, b, r, lambda, beta, vx, vy, vz, vlos, pmra, pmdec, mass
+-- Full output file includes: x, y, z, l, b, r, vx, vy, vz, mass, vlos, pmra, pmdec, [lambda, beta]
+-- NOTE: Lambda and Beta are optional and will only be included if the histogram parameters are set in makeHistogram()
 
 -- -- -- -- -- -- -- -- -- HISTOGRAM   -- -- -- -- -- -- -- -- -- -- -- -- --
+
 lda_bins        = 50      -- number of bins in lamdba direction
 lda_lower_range = -150    -- lower range for lambda
 lda_upper_range = 150     -- upepr range for lamdba
@@ -119,6 +230,13 @@ use_vlos_comp        = true  -- calculate average los velocity, use in likelihoo
 use_avg_dist         = true  -- calculate average distance, use in likelihood
 use_pm_comp          = true  -- calculate proper motion, use in likelihood
 
+-- if using momentum likelihood, include momentum information in the parameters of the input
+-- histogram (after <histogram> )with the following lines:
+    -- L = {Lx, Ly, Lz} (angular momentum vector)
+    -- LErr = {Err_Lx, Err_Ly, Err_Lz} (uncertainty in angular momentum vector)
+-- These are in units of kpc^2/Gyr (no mass included)
+use_momentum         = true  -- calculate angular momentum, use in likelihood
+
 -- number of additional forward evolutions to do to calibrate the rotation of the bar
 -- numCalibrationRuns + 1 additional forward evolutions will be done
 -- if no bar potential is being used, this variable will be ignored
@@ -131,7 +249,7 @@ numCalibrationRuns = 0
 -- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
 
-useMultiOutputs       = true      -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
 freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
 
 timestep_control      = false       -- -- control number of steps                                                          -- --
@@ -140,23 +258,9 @@ Ntime_steps           = 3000        -- -- number of timesteps to run            
 use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
 max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
 
-generateInitialOutput = true        -- -- save initial dwarf galaxy state to initial.out before evolution                  -- --
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         
-
-
-
-
--- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
--- these only get used if only 6 parameters are input from shell script
--- otherwise they get reset later with the inputs (if 11 given)
-preset_orbit_parameter_l  = 258
-preset_orbit_parameter_b  = 45.8
-preset_orbit_parameter_r  = 21.5
-preset_orbit_parameter_vx = -185.5
-preset_orbit_parameter_vy = 54.7
-preset_orbit_parameter_vz = 147.4
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
         
 -- -- -- -- -- -- -- -- -- CHECK TIMESTEPS -- -- -- -- -- -- -- -- 
 TooManyTimesteps = 0
@@ -168,11 +272,11 @@ function makePotential()
    else
         --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
         return  Potential.create{
-            spherical = Spherical.hernquist{ mass  = 1.52954402e5, scale = 0.7 },
-            disk      = Disk.miyamotoNagai{ mass = 4.45865888e5, scaleLength = 6.5, scaleHeight = 0.26 },
-            disk2     = Disk.none{ mass = 3.0e5 },
-            halo      = Halo.logarithmic{ vhalo = 74.61, scaleLength = 12.0, flattenZ = 1.0 }
-        }--vhalo = 74.61 kpc/gy = 73 km/s
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
    end
 end
 
@@ -205,6 +309,8 @@ function get_timestep()
     end
 
     if ((evolveTime/t > 150000 or t ~= t) and not timestep_control) then
+        -- We could throw an error here, but instead let it run fast and return a poor likelihood
+        -- This way users won't see errors in their workunit logs
         TooManyTimesteps = 1
         t = evolveTime/4.0
     end
@@ -216,8 +322,11 @@ end
 function get_soft_par()
     --softening parameter only calculated based on dwarf,
     --so if manual bodies is turned on the calculated s.p. may be too large
-    sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d, UseOldSofteningLength)
-
+    if (UseOldSofteningLength == 1) then
+        sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d)
+    else
+        sp = calculateEps2Dwarf(comp1, totalLightBodies)
+    end
     if ((manual_bodies or use_max_soft_par) and (sp > max_soft_par^2)) then --dealing with softening parameter squared
         print("Using maximum softening parameter value of " .. tostring(max_soft_par) .. " kpc")
         return max_soft_par^2
@@ -232,7 +341,7 @@ function makeContext()
       timeEvolve  = evolveTime,
       timeBack    = revOrbTime,
       timestep    = get_timestep(),
-      eps2        = 1e-4,
+      eps2        = 1e-4, 
       b           = orbit_parameter_b,
       r           = orbit_parameter_r,
       vx          = orbit_parameter_vx,
@@ -252,6 +361,7 @@ function makeContext()
       useVlos       = use_vlos_comp,
       useDist       = use_avg_dist,
       usePropMot    = use_pm_comp,
+      useMomentum   = use_momentum,
       Nstep_control = timestep_control,
       Ntsteps       = Ntime_steps,
       BetaSigma     = SigmaCutoff,
@@ -287,7 +397,9 @@ function makeBodies(ctx, potential)
   local firstModel
   local finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity
     if TooManyTimesteps == 1 then
+        -- Setting bodies to 1 ensures worst case likelihood
         totalBodies = 1
+        totalLightBodies = 1
     end
 
     if(run_null_potential == true and manual_bodies == true) then
@@ -302,8 +414,8 @@ function makeBodies(ctx, potential)
 	            potential   = potential,
 	            position    = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
 	            velocity    = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
-	            LMCposition = Vector.create(-1.1, -41.1, -27.9),
-	            LMCvelocity = Vector.create(-57, -226, 221),
+	            LMCposition = Vector.create(-0.52, -40.8, -26.5),
+	            LMCvelocity = Vector.create(-58.2, -231, 226),
 		            LMCfunction = LMC_function,
                     LMCmass     = LMC_Mass,
                     LMCscale    = LMC_scaleRadius,
@@ -339,12 +451,8 @@ function makeBodies(ctx, potential)
         print('Printing reverse orbit')
     end
 
+    if(ModelComponents == 2) then         
 
-    if(ModelComponents == 2) then 
-        -- Create components
-        local comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        local comp2 = Dwarf.general_hernquist{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        
         firstModel = predefinedModels.mixeddwarf{
             nbody         = totalBodies,
             nbody_baryon  = totalLightBodies,
@@ -356,21 +464,15 @@ function makeBodies(ctx, potential)
             ignore        = true
         }
         
-        -- Store components in the model's table (needed for stability test)
-        firstModel.components = {
-            comp1 = comp1,
-            comp2 = comp2,
-        }
-        
     elseif(ModelComponents == 1) then
-        firstModel = predefinedModels.plummer{  -- Dwarf Options: plummer, nfw, hernq, isotropic
+        firstModel = predefinedModels.plummer{ 
             nbody       = totalBodies,
-            prng        = prng,
-            position    = finalPosition,
-            velocity    = finalVelocity,
             mass        = mass_l,
             scaleRadius = rscale_l,
-            ignore      = false
+            position    = finalPosition,
+            velocity    = finalVelocity,
+            ignore      = false,
+            prng        = prng
         }
   
     end
@@ -408,66 +510,18 @@ function makeHistogram()
      
      betaStart = bta_lower_range,
      betaEnd   = bta_upper_range,
-     betaBins  = bta_bins
+     betaBins  = bta_bins,
+
+     -- Optional params
+     L = {0.0, 0.0, 0.0}, --If any L components are nonzero, will use this L and LErr for momentum likelihood
+     LErr = {0.0, 0.0, 0.0}, --This will overwrite any momentum values passed in through histogram. Input these as lua tables
+
+     nRange = 0, --If non-zero, will use EMDRange values below. Overwrites values given in input histogram
+     EMDRange = {} --Make sure this has an even number of elements and matches nRange. Input as a lua table
 }
 end
 
 
-arg = { ... } -- -- TAKING USER INPUT
-assert((#arg == 6 or #arg == 7 or #arg == 12 or #arg == 13), "Expects either 6, 7, 12, or 13 arguments, and optional manual body list")
-assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
-argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
---argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
-prng = DSFMT.create(argSeed)
-
--- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
-function round(num, places)
-  local mult = 10.0^(places)
-  return floor(num * mult + 0.5) / mult
-end
-
--- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
-dec = 9.0
-evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
-time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
-rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
-light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
-mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
-light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
-if (#arg >= 7) then
-    if (#arg >= 12) then
-    orbit_parameter_l   = round( tonumber(arg[7]), dec )
-    orbit_parameter_b   = round( tonumber(arg[8]), dec )
-    orbit_parameter_r   = round( tonumber(arg[9]), dec )
-    orbit_parameter_vx  = round( tonumber(arg[10]), dec )
-    orbit_parameter_vy  = round( tonumber(arg[11]), dec )
-    orbit_parameter_vz  = round( tonumber(arg[12]), dec )
-    if (#arg >= 13) then
-        LMC_Mass = round( tonumber(arg[13]), dec )
-    else
-        LMC_Mass = preset_LMC_Mass
-        end
-        manual_body_file = arg[15]
-    else
-        orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    LMC_Mass = round( tonumber(arg[7]), dec )
-    manual_body_file = arg[7] -- File with Individual Particles (.out file)
-    end
-else
-    LMC_Mass = preset_LMC_Mass
-    orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    manual_body_file = arg[8]
-end
 
 -- -- -- -- -- -- -- -- -- DWARF PARAMETERS   -- -- -- -- -- -- -- --
 revOrbTime = evolveTime / time_ratio
@@ -479,17 +533,6 @@ else
 end
 
 
-if(ModelComponents == 1) then
-   dwarfMass = mass_l
-   rscale_t  = rscale_l
-   rscale_d  = 1.0
-   mass_d    = 0.0
-else
-   dwarfMass = mass_l / light_mass_ratio
-   rscale_t  = rscale_l / light_r_ratio
-   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
-   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
-end
    
 
 if(manual_bodies and manual_body_file == nil) then 

--- a/nbody/tests/mixeddwarf_models/plummer_nfw.lua
+++ b/nbody/tests/mixeddwarf_models/plummer_nfw.lua
@@ -3,19 +3,13 @@
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- Test Environment Lua File 
 -- Plummer-NFW Dwarf model 
--- Total number of bodies are meant to be run with Eric's Parameters 
--- baryon scale radius = 0.181216 kpc
--- radius ratio = 0.182799
--- baryon mass = 1.22251 SMU
--- mass ratio = 0.0126171
--- This gives a ratio of mass per baryon particle/ mass per dark matter particle of 0.1
 -- Set to null potential to test stability of dwarf (no Milky Way potential or LMC)
 -- Set multiple outputs to true 
 -- Set generate initial output to true 
 -- Softening parameter currently hard coded since the calculation needs to be changed
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- DEAR LUA USER:
 -- This is the developer version of the lua parameter file. 
 -- It gives all the options you can have. 
@@ -34,40 +28,23 @@
 -- MUST still include dwarf parameter list
 -- can control what model to use below
 -- simulation time still taken as the first parameter in the list
+
+-- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
+-- Structural changes to this file also need to be changed in the 
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- especially if the changes are not backwards compatible with the previous format
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
+-- these only get used if only 6 parameters are input from shell script
+-- otherwise they get reset later with the inputs (if 11 given)
+preset_orbit_parameter_l  = 258     -- deg
+preset_orbit_parameter_b  = 45.8    -- deg
+preset_orbit_parameter_r  = 21.5    -- kpc
+preset_orbit_parameter_vx = -185.5  -- kpc/Gyr
+preset_orbit_parameter_vy = 54.7    -- kpc/Gyr
+preset_orbit_parameter_vz = 147.4   -- kpc/Gyr
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-        
-        
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
--- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 40000   -- -- NUMBER OF TOTAL BODIES                                                   -- --
-totalLightBodies      = 10000   -- -- NUMBER OF LIGHT MATTER BODIES                                            -- --
-
-nbodyLikelihoodMethod = "EMD"   -- -- HIST COMPARE METHOD                                                      -- --
-nbodyMinVersion       = "1.93"  -- -- MINIMUM APP VERSION                                                      -- --
-
-run_null_potential    = true   -- -- NULL POTENTIAL SWITCH                                                    -- --
-use_tree_code         = true    -- -- USE TREE CODE NOT EXACT                                                  -- --
-print_reverse_orbit   = false   -- -- PRINT REVERSE ORBIT SWITCH                                               -- --
-print_out_parameters  = false   -- -- PRINT OUT ALL PARAMETERS                                                 -- --
-
-LMC_body              = false    -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                            -- --
-LMC_function          = 1
-LMC_scaleRadius       = 15      -- --  kpc
-LMC_cutoff            = 16.6
-preset_LMC_Mass       = 449865.888  -- -- SMU -- -- only if <12 params are used                                -- --
-LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
-CoulombLogarithm      = 0.470003629 -- -- (ln(1.6)) COULOMB LOGARITHM USED IN DYNAMICAL FRACTION CALCULATION   -- --
-
-SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
-SunVelx               = 10.3      -- -- Sun's x-velocity                                                       -- --
-SunVely               = 229.2     -- -- Sun's y-velocity                                                       -- --
-SunVelz               = 6.9       -- -- Sun's z-velocity                                                       -- --      
-
-UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-
-
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- -- -- -- -- -- -- -- -- MODEL SETTINGS -- -- -- -- -- -- -- -- -- -- -- --
@@ -78,7 +55,139 @@ UseOldSofteningLength = 0         -- -- Uses old softening length formula from v
 -- --       0 - NO DWARF MODEL         -- -- -- -- -- -- -- -- -- -- -- -- --
 ModelComponents   = 2         -- -- TWO COMPONENTS SWITCH   -- -- -- -- -- --
 manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+        
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+
+nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
+nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
+
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
+print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
+print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
+
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
+LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
+LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
+preset_LMC_Mass       = 449865.888  -- -- SMU (used unless specified in arguments)                             -- --
+LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
+CoulombLogarithm      = 15      -- -- ln(r/1.22*CoulombLogarithm) (Patel et al. 2020) COULOMB LOGARITHM USED   -- --
+                                -- -- IN DYNAMICAL FRACTION CALCULATION                                        -- --
+
+SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
+SunVelx               = 10.3      -- -- Sun's x-velocity (kpc/Gyr) (Hogg et al. (2005))                        -- --
+SunVely               = 229.2     -- -- Sun's y-velocity (kpc/Gyr)                                             -- --
+SunVelz               = 6.9       -- -- Sun's z-velocity (kpc/Gyr)                                             -- --
+
+UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+arg = { ... } -- -- TAKING USER INPUT
+assert((#arg == 6 or #arg == 7 or #arg == 8 or #arg == 11 or #arg == 12 or #arg == 13), "Expects either 6, 7, 8, 11, 12, or 13 arguments")
+assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
+argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
+--argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
+prng = DSFMT.create(argSeed)
+-- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
+function round(num, places)
+  local mult = 10.0^(places)
+  return floor(num * mult + 0.5) / mult
+end
+
+-- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
+dec = 9.0
+evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
+time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
+rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
+light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
+mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
+light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
+if (#arg == 7) then
+    if manual_bodies then
+        manual_body_file = arg[7]
+        LMC_Mass = preset_LMC_Mass
+    else 
+        LMC_Mass = round( tonumber(arg[7]), dec )
+    end
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 8) then
+    LMC_Mass = round( tonumber(arg[7]), dec )
+    manual_body_file = arg[8]
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 11) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = preset_LMC_Mass
+elseif (#arg == 12) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    if manual_bodies then
+        manual_body_file = arg[12]
+        LMC_Mass = preset_LMC_Mass
+    else
+        LMC_Mass = round( tonumber(arg[12]), dec )
+    end
+elseif (#arg == 13) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = round( tonumber(arg[12]), dec )
+    manual_body_file = arg[13]
+else
+    -- fallback to preset orbit parameters and LMC mass if not enough args
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+    LMC_Mass = preset_LMC_Mass
+end 
+
+if(ModelComponents == 1) then
+   dwarfMass = mass_l
+   rscale_t  = rscale_l
+   rscale_d  = 1.0
+   mass_d    = 0.0
+else
+   dwarfMass = mass_l / light_mass_ratio
+   rscale_t  = rscale_l / light_r_ratio
+   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
+   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
+end
+
+--component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
+--calculate dwarf-based softening length
+comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.nfw{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
 
 
 
@@ -89,9 +198,11 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 
 -- -- -- -- -- -- -- --  OUTPUT SETTINGS  -- -- -- -- -- -- -- -- -- -- -- --
 generateSimpleOutput = true       -- Simple output file includes: x, y, z, vx, vy, vz, mass
--- Full output file includes: x, y, z, l, b, r, lambda, beta, vx, vy, vz, vlos, pmra, pmdec, mass
+-- Full output file includes: x, y, z, l, b, r, vx, vy, vz, mass, vlos, pmra, pmdec, [lambda, beta]
+-- NOTE: Lambda and Beta are optional and will only be included if the histogram parameters are set in makeHistogram()
 
 -- -- -- -- -- -- -- -- -- HISTOGRAM   -- -- -- -- -- -- -- -- -- -- -- -- --
+
 lda_bins        = 50      -- number of bins in lamdba direction
 lda_lower_range = -150    -- lower range for lambda
 lda_upper_range = 150     -- upepr range for lamdba
@@ -119,6 +230,13 @@ use_vlos_comp        = true  -- calculate average los velocity, use in likelihoo
 use_avg_dist         = true  -- calculate average distance, use in likelihood
 use_pm_comp          = true  -- calculate proper motion, use in likelihood
 
+-- if using momentum likelihood, include momentum information in the parameters of the input
+-- histogram (after <histogram> )with the following lines:
+    -- L = {Lx, Ly, Lz} (angular momentum vector)
+    -- LErr = {Err_Lx, Err_Ly, Err_Lz} (uncertainty in angular momentum vector)
+-- These are in units of kpc^2/Gyr (no mass included)
+use_momentum         = true  -- calculate angular momentum, use in likelihood
+
 -- number of additional forward evolutions to do to calibrate the rotation of the bar
 -- numCalibrationRuns + 1 additional forward evolutions will be done
 -- if no bar potential is being used, this variable will be ignored
@@ -131,7 +249,7 @@ numCalibrationRuns = 0
 -- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
 
-useMultiOutputs       = true      -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
 freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
 
 timestep_control      = false       -- -- control number of steps                                                          -- --
@@ -140,23 +258,9 @@ Ntime_steps           = 3000        -- -- number of timesteps to run            
 use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
 max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
 
-generateInitialOutput = true        -- -- save initial dwarf galaxy state to initial.out before evolution                  -- --
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         
-
-
-
-
--- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
--- these only get used if only 6 parameters are input from shell script
--- otherwise they get reset later with the inputs (if 11 given)
-preset_orbit_parameter_l  = 258
-preset_orbit_parameter_b  = 45.8
-preset_orbit_parameter_r  = 21.5
-preset_orbit_parameter_vx = -185.5
-preset_orbit_parameter_vy = 54.7
-preset_orbit_parameter_vz = 147.4
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
         
 -- -- -- -- -- -- -- -- -- CHECK TIMESTEPS -- -- -- -- -- -- -- -- 
 TooManyTimesteps = 0
@@ -168,11 +272,11 @@ function makePotential()
    else
         --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
         return  Potential.create{
-            spherical = Spherical.hernquist{ mass  = 1.52954402e5, scale = 0.7 },
-            disk      = Disk.miyamotoNagai{ mass = 4.45865888e5, scaleLength = 6.5, scaleHeight = 0.26 },
-            disk2     = Disk.none{ mass = 3.0e5 },
-            halo      = Halo.logarithmic{ vhalo = 74.61, scaleLength = 12.0, flattenZ = 1.0 }
-        }--vhalo = 74.61 kpc/gy = 73 km/s
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
    end
 end
 
@@ -205,6 +309,8 @@ function get_timestep()
     end
 
     if ((evolveTime/t > 150000 or t ~= t) and not timestep_control) then
+        -- We could throw an error here, but instead let it run fast and return a poor likelihood
+        -- This way users won't see errors in their workunit logs
         TooManyTimesteps = 1
         t = evolveTime/4.0
     end
@@ -216,8 +322,11 @@ end
 function get_soft_par()
     --softening parameter only calculated based on dwarf,
     --so if manual bodies is turned on the calculated s.p. may be too large
-    sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d, UseOldSofteningLength)
-
+    if (UseOldSofteningLength == 1) then
+        sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d)
+    else
+        sp = calculateEps2Dwarf(comp1, totalLightBodies)
+    end
     if ((manual_bodies or use_max_soft_par) and (sp > max_soft_par^2)) then --dealing with softening parameter squared
         print("Using maximum softening parameter value of " .. tostring(max_soft_par) .. " kpc")
         return max_soft_par^2
@@ -232,7 +341,7 @@ function makeContext()
       timeEvolve  = evolveTime,
       timeBack    = revOrbTime,
       timestep    = get_timestep(),
-      eps2        = 1e-4,
+      eps2        = get_soft_par(), 
       b           = orbit_parameter_b,
       r           = orbit_parameter_r,
       vx          = orbit_parameter_vx,
@@ -252,6 +361,7 @@ function makeContext()
       useVlos       = use_vlos_comp,
       useDist       = use_avg_dist,
       usePropMot    = use_pm_comp,
+      useMomentum   = use_momentum,
       Nstep_control = timestep_control,
       Ntsteps       = Ntime_steps,
       BetaSigma     = SigmaCutoff,
@@ -287,7 +397,9 @@ function makeBodies(ctx, potential)
   local firstModel
   local finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity
     if TooManyTimesteps == 1 then
+        -- Setting bodies to 1 ensures worst case likelihood
         totalBodies = 1
+        totalLightBodies = 1
     end
 
     if(run_null_potential == true and manual_bodies == true) then
@@ -302,8 +414,8 @@ function makeBodies(ctx, potential)
 	            potential   = potential,
 	            position    = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
 	            velocity    = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
-	            LMCposition = Vector.create(-1.1, -41.1, -27.9),
-	            LMCvelocity = Vector.create(-57, -226, 221),
+	            LMCposition = Vector.create(-0.52, -40.8, -26.5),
+	            LMCvelocity = Vector.create(-58.2, -231, 226),
 		            LMCfunction = LMC_function,
                     LMCmass     = LMC_Mass,
                     LMCscale    = LMC_scaleRadius,
@@ -339,12 +451,8 @@ function makeBodies(ctx, potential)
         print('Printing reverse orbit')
     end
 
+    if(ModelComponents == 2) then         
 
-    if(ModelComponents == 2) then 
-        -- Create components
-        local comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        local comp2 = Dwarf.nfw{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        
         firstModel = predefinedModels.mixeddwarf{
             nbody         = totalBodies,
             nbody_baryon  = totalLightBodies,
@@ -356,21 +464,15 @@ function makeBodies(ctx, potential)
             ignore        = true
         }
         
-        -- Store components in the model's table (needed for stability test)
-        firstModel.components = {
-            comp1 = comp1,
-            comp2 = comp2,
-        }
-        
     elseif(ModelComponents == 1) then
-        firstModel = predefinedModels.plummer{  -- Dwarf Options: plummer, nfw, hernq, isotropic
+        firstModel = predefinedModels.plummer{ 
             nbody       = totalBodies,
-            prng        = prng,
-            position    = finalPosition,
-            velocity    = finalVelocity,
             mass        = mass_l,
             scaleRadius = rscale_l,
-            ignore      = false
+            position    = finalPosition,
+            velocity    = finalVelocity,
+            ignore      = false,
+            prng        = prng
         }
   
     end
@@ -408,66 +510,18 @@ function makeHistogram()
      
      betaStart = bta_lower_range,
      betaEnd   = bta_upper_range,
-     betaBins  = bta_bins
+     betaBins  = bta_bins,
+
+     -- Optional params
+     L = {0.0, 0.0, 0.0}, --If any L components are nonzero, will use this L and LErr for momentum likelihood
+     LErr = {0.0, 0.0, 0.0}, --This will overwrite any momentum values passed in through histogram. Input these as lua tables
+
+     nRange = 0, --If non-zero, will use EMDRange values below. Overwrites values given in input histogram
+     EMDRange = {} --Make sure this has an even number of elements and matches nRange. Input as a lua table
 }
 end
 
 
-arg = { ... } -- -- TAKING USER INPUT
-assert((#arg == 6 or #arg == 7 or #arg == 12 or #arg == 13), "Expects either 6, 7, 12, or 13 arguments, and optional manual body list")
-assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
-argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
---argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
-prng = DSFMT.create(argSeed)
-
--- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
-function round(num, places)
-  local mult = 10.0^(places)
-  return floor(num * mult + 0.5) / mult
-end
-
--- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
-dec = 9.0
-evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
-time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
-rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
-light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
-mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
-light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
-if (#arg >= 7) then
-    if (#arg >= 12) then
-    orbit_parameter_l   = round( tonumber(arg[7]), dec )
-    orbit_parameter_b   = round( tonumber(arg[8]), dec )
-    orbit_parameter_r   = round( tonumber(arg[9]), dec )
-    orbit_parameter_vx  = round( tonumber(arg[10]), dec )
-    orbit_parameter_vy  = round( tonumber(arg[11]), dec )
-    orbit_parameter_vz  = round( tonumber(arg[12]), dec )
-    if (#arg >= 13) then
-        LMC_Mass = round( tonumber(arg[13]), dec )
-    else
-        LMC_Mass = preset_LMC_Mass
-        end
-        manual_body_file = arg[15]
-    else
-        orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    LMC_Mass = round( tonumber(arg[7]), dec )
-    manual_body_file = arg[7] -- File with Individual Particles (.out file)
-    end
-else
-    LMC_Mass = preset_LMC_Mass
-    orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    manual_body_file = arg[8]
-end
 
 -- -- -- -- -- -- -- -- -- DWARF PARAMETERS   -- -- -- -- -- -- -- --
 revOrbTime = evolveTime / time_ratio
@@ -479,17 +533,6 @@ else
 end
 
 
-if(ModelComponents == 1) then
-   dwarfMass = mass_l
-   rscale_t  = rscale_l
-   rscale_d  = 1.0
-   mass_d    = 0.0
-else
-   dwarfMass = mass_l / light_mass_ratio
-   rscale_t  = rscale_l / light_r_ratio
-   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
-   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
-end
    
 
 if(manual_bodies and manual_body_file == nil) then 

--- a/nbody/tests/mixeddwarf_models/plummer_plummer.lua
+++ b/nbody/tests/mixeddwarf_models/plummer_plummer.lua
@@ -3,19 +3,13 @@
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- Test Environment Lua File 
 -- Plummer-Plummer Dwarf model 
--- Total number of bodies are meant to be run with Eric's Parameters 
--- baryon scale radius = 0.181216 kpc
--- radius ratio = 0.182799
--- baryon mass = 1.22251 SMU
--- mass ratio = 0.0126171
--- This gives a ratio of mass per baryon particle/ mass per dark matter particle of 0.1
 -- Set to null potential to test stability of dwarf (no Milky Way potential or LMC)
 -- Set multiple outputs to true 
 -- Set generate initial output to true 
 -- Softening parameter currently hard coded since the calculation needs to be changed
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- DEAR LUA USER:
 -- This is the developer version of the lua parameter file. 
 -- It gives all the options you can have. 
@@ -34,40 +28,23 @@
 -- MUST still include dwarf parameter list
 -- can control what model to use below
 -- simulation time still taken as the first parameter in the list
+
+-- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- IMPORTANT -- 
+-- Structural changes to this file also need to be changed in the 
+-- lua files in the tests directory (nbody/tests/mixeddwarf_models/)
+-- especially if the changes are not backwards compatible with the previous format
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+-- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
+-- these only get used if only 6 parameters are input from shell script
+-- otherwise they get reset later with the inputs (if 11 given)
+preset_orbit_parameter_l  = 258     -- deg
+preset_orbit_parameter_b  = 45.8    -- deg
+preset_orbit_parameter_r  = 21.5    -- kpc
+preset_orbit_parameter_vx = -185.5  -- kpc/Gyr
+preset_orbit_parameter_vy = 54.7    -- kpc/Gyr
+preset_orbit_parameter_vz = 147.4   -- kpc/Gyr
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
-        
-        
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
--- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-totalBodies           = 40000   -- -- NUMBER OF TOTAL BODIES                                                   -- --
-totalLightBodies      = 10000   -- -- NUMBER OF LIGHT MATTER BODIES                                            -- --
-
-nbodyLikelihoodMethod = "EMD"   -- -- HIST COMPARE METHOD                                                      -- --
-nbodyMinVersion       = "1.93"  -- -- MINIMUM APP VERSION                                                      -- --
-
-run_null_potential    = true   -- -- NULL POTENTIAL SWITCH                                                    -- --
-use_tree_code         = true    -- -- USE TREE CODE NOT EXACT                                                  -- --
-print_reverse_orbit   = false   -- -- PRINT REVERSE ORBIT SWITCH                                               -- --
-print_out_parameters  = false   -- -- PRINT OUT ALL PARAMETERS                                                 -- --
-
-LMC_body              = false    -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                            -- --
-LMC_function          = 1
-LMC_scaleRadius       = 15      -- --  kpc                                                                     -- --
-LMC_cutoff            = 16.6
-preset_LMC_Mass       = 449865.888  -- -- SMU -- -- only if <12 params are used                                -- --
-LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
-CoulombLogarithm      = 0.470003629 -- -- (ln(1.6)) COULOMB LOGARITHM USED IN DYNAMICAL FRACTION CALCULATION   -- --
-
-SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
-SunVelx               = 10.3      -- -- Sun's x-velocity                                                       -- --
-SunVely               = 229.2     -- -- Sun's y-velocity                                                       -- --
-SunVelz               = 6.9       -- -- Sun's z-velocity                                                       -- --      
-
-UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-
-
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
 -- -- -- -- -- -- -- -- -- MODEL SETTINGS -- -- -- -- -- -- -- -- -- -- -- --
@@ -78,7 +55,139 @@ UseOldSofteningLength = 0         -- -- Uses old softening length formula from v
 -- --       0 - NO DWARF MODEL         -- -- -- -- -- -- -- -- -- -- -- -- --
 ModelComponents   = 2         -- -- TWO COMPONENTS SWITCH   -- -- -- -- -- --
 manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+        
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+-- -- -- -- -- -- -- -- -- STANDARD  SETTINGS   -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --      
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+totalBodies           = 40000     -- -- NUMBER OF TOTAL BODIES                                               -- --
+totalLightBodies      = 10000       -- -- NUMBER OF LIGHT MATTER BODIES                                        -- --
+
+nbodyLikelihoodMethod = "EMD"       -- -- HIST COMPARE METHOD                                                  -- --
+nbodyMinVersion       = "1.95"      -- -- MINIMUM APP VERSION                                                  -- --
+
+run_null_potential    = true       -- -- NULL POTENTIAL SWITCH                                                -- --
+use_tree_code         = true        -- -- USE TREE CODE NOT EXACT                                              -- --
+print_reverse_orbit   = false       -- -- PRINT REVERSE ORBIT SWITCH (WORKS FOR LMC_body = false)              -- --
+print_out_parameters  = false       -- -- PRINT OUT ALL PARAMETERS                                             -- --
+
+LMC_body              = false        -- -- PRESENCE OF LMC (TURN OFF FOR NULL POTENTIAL)                        -- --
+LMC_function          = 1           -- -- 1: Plummer 2: Henrquist 3: Hernquist with cutoff                     -- --
+LMC_scaleRadius       = 15          -- --  kpc                                                                 -- --
+LMC_cutoff            = 16          -- --  kpc  This is used only for Hernquist with cutoff                    -- --
+preset_LMC_Mass       = 449865.888  -- -- SMU (used unless specified in arguments)                             -- --
+LMC_DynamicalFriction = true    -- -- LMC DYNAMICAL FRICTION SWITCH (IGNORED IF NO LMC)                        -- --
+CoulombLogarithm      = 15      -- -- ln(r/1.22*CoulombLogarithm) (Patel et al. 2020) COULOMB LOGARITHM USED   -- --
+                                -- -- IN DYNAMICAL FRACTION CALCULATION                                        -- --
+
+SunGCDist             = 8.0       -- -- Distance between Sun and Galactic Center                               -- --
+SunVelx               = 10.3      -- -- Sun's x-velocity (kpc/Gyr) (Hogg et al. (2005))                        -- --
+SunVely               = 229.2     -- -- Sun's y-velocity (kpc/Gyr)                                             -- --
+SunVelz               = 6.9       -- -- Sun's z-velocity (kpc/Gyr)                                             -- --
+
+UseOldSofteningLength = 0         -- -- Uses old softening length formula from v1.76 and eariler               -- --
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+arg = { ... } -- -- TAKING USER INPUT
+assert((#arg == 6 or #arg == 7 or #arg == 8 or #arg == 11 or #arg == 12 or #arg == 13), "Expects either 6, 7, 8, 11, 12, or 13 arguments")
+assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
+argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
+--argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
+prng = DSFMT.create(argSeed)
+-- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
+function round(num, places)
+  local mult = 10.0^(places)
+  return floor(num * mult + 0.5) / mult
+end
+
+-- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
+dec = 9.0
+evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
+time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
+rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
+light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
+mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
+light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
+if (#arg == 7) then
+    if manual_bodies then
+        manual_body_file = arg[7]
+        LMC_Mass = preset_LMC_Mass
+    else 
+        LMC_Mass = round( tonumber(arg[7]), dec )
+    end
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 8) then
+    LMC_Mass = round( tonumber(arg[7]), dec )
+    manual_body_file = arg[8]
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+elseif (#arg == 11) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = preset_LMC_Mass
+elseif (#arg == 12) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    if manual_bodies then
+        manual_body_file = arg[12]
+        LMC_Mass = preset_LMC_Mass
+    else
+        LMC_Mass = round( tonumber(arg[12]), dec )
+    end
+elseif (#arg == 13) then
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = round( tonumber(arg[7]), dec )
+    orbit_parameter_r   = round( tonumber(arg[8]), dec )
+    orbit_parameter_vx  = round( tonumber(arg[9]), dec )
+    orbit_parameter_vy  = round( tonumber(arg[10]), dec )
+    orbit_parameter_vz  = round( tonumber(arg[11]), dec )
+    LMC_Mass = round( tonumber(arg[12]), dec )
+    manual_body_file = arg[13]
+else
+    -- fallback to preset orbit parameters and LMC mass if not enough args
+    orbit_parameter_l   = preset_orbit_parameter_l
+    orbit_parameter_b   = preset_orbit_parameter_b
+    orbit_parameter_r   = preset_orbit_parameter_r
+    orbit_parameter_vx  = preset_orbit_parameter_vx
+    orbit_parameter_vy  = preset_orbit_parameter_vy
+    orbit_parameter_vz  = preset_orbit_parameter_vz
+    LMC_Mass = preset_LMC_Mass
+end 
+
+if(ModelComponents == 1) then
+   dwarfMass = mass_l
+   rscale_t  = rscale_l
+   rscale_d  = 1.0
+   mass_d    = 0.0
+else
+   dwarfMass = mass_l / light_mass_ratio
+   rscale_t  = rscale_l / light_r_ratio
+   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
+   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
+end
+
+--component 1 and 2 for 2 component model. comp 1 should always be updated even for 1 component, as it is used to 
+--calculate dwarf-based softening length
+comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
+comp2 = Dwarf.plummer{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
 
 
 
@@ -89,9 +198,11 @@ manual_bodies     = false     -- -- USE THE MANUAL BODY LIST   -- -- -- -- --
 
 -- -- -- -- -- -- -- --  OUTPUT SETTINGS  -- -- -- -- -- -- -- -- -- -- -- --
 generateSimpleOutput = true       -- Simple output file includes: x, y, z, vx, vy, vz, mass
--- Full output file includes: x, y, z, l, b, r, lambda, beta, vx, vy, vz, vlos, pmra, pmdec, mass
+-- Full output file includes: x, y, z, l, b, r, vx, vy, vz, mass, vlos, pmra, pmdec, [lambda, beta]
+-- NOTE: Lambda and Beta are optional and will only be included if the histogram parameters are set in makeHistogram()
 
 -- -- -- -- -- -- -- -- -- HISTOGRAM   -- -- -- -- -- -- -- -- -- -- -- -- --
+
 lda_bins        = 50      -- number of bins in lamdba direction
 lda_lower_range = -150    -- lower range for lambda
 lda_upper_range = 150     -- upepr range for lamdba
@@ -119,6 +230,13 @@ use_vlos_comp        = true  -- calculate average los velocity, use in likelihoo
 use_avg_dist         = true  -- calculate average distance, use in likelihood
 use_pm_comp          = true  -- calculate proper motion, use in likelihood
 
+-- if using momentum likelihood, include momentum information in the parameters of the input
+-- histogram (after <histogram> )with the following lines:
+    -- L = {Lx, Ly, Lz} (angular momentum vector)
+    -- LErr = {Err_Lx, Err_Ly, Err_Lz} (uncertainty in angular momentum vector)
+-- These are in units of kpc^2/Gyr (no mass included)
+use_momentum         = true  -- calculate angular momentum, use in likelihood
+
 -- number of additional forward evolutions to do to calibrate the rotation of the bar
 -- numCalibrationRuns + 1 additional forward evolutions will be done
 -- if no bar potential is being used, this variable will be ignored
@@ -131,7 +249,7 @@ numCalibrationRuns = 0
 -- -- -- -- -- -- These options only work if you compile nbody with  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 -- -- -- -- -- -- the -DNBODY_DEV_OPTIONS set to on -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- - -- -- -- -- -- -- --  
 
-useMultiOutputs       = true      -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
+useMultiOutputs       = true     -- -- WRITE MULTIPLE OUTPUTS                                                            -- --
 freqOfOutputs         = 100         -- -- FREQUENCY OF WRITING OUTPUTS                                                     -- --
 
 timestep_control      = false       -- -- control number of steps                                                          -- --
@@ -140,23 +258,9 @@ Ntime_steps           = 3000        -- -- number of timesteps to run            
 use_max_soft_par      = false       -- -- limit the softening parameter value to a max value                               -- --
 max_soft_par          = 0.8         -- -- kpc, if switch above is turned on, use this as the max softening parameter       -- --
 
-generateInitialOutput = true        -- -- save initial dwarf galaxy state to initial.out before evolution                  -- --
+generateInitialOutput = true       -- -- save initial dwarf galaxy state to initial.out before evolution                   -- --
 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         
-
-
-
-
--- -- -- -- -- -- -- -- -- DWARF STARTING LOCATION   -- -- -- -- -- -- -- --
--- these only get used if only 6 parameters are input from shell script
--- otherwise they get reset later with the inputs (if 11 given)
-preset_orbit_parameter_l  = 258
-preset_orbit_parameter_b  = 45.8
-preset_orbit_parameter_r  = 21.5
-preset_orbit_parameter_vx = -185.5
-preset_orbit_parameter_vy = 54.7
-preset_orbit_parameter_vz = 147.4
--- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
         
 -- -- -- -- -- -- -- -- -- CHECK TIMESTEPS -- -- -- -- -- -- -- -- 
 TooManyTimesteps = 0
@@ -168,11 +272,11 @@ function makePotential()
    else
         --NOTE: To exclude a component from the potential, set component to "<component_name>.none" and include only an arbitrary "mass" argument
         return  Potential.create{
-            spherical = Spherical.hernquist{ mass  = 1.52954402e5, scale = 0.7 },
-            disk      = Disk.miyamotoNagai{ mass = 4.45865888e5, scaleLength = 6.5, scaleHeight = 0.26 },
-            disk2     = Disk.none{ mass = 3.0e5 },
-            halo      = Halo.logarithmic{ vhalo = 74.61, scaleLength = 12.0, flattenZ = 1.0 }
-        }--vhalo = 74.61 kpc/gy = 73 km/s
+            spherical = Spherical.hernquist{ mass  = 20243.9650, scale = 0.442 },
+            disk      = Disk.miyamotoNagai{ mass = 305908.804, scaleLength = 3.0, scaleHeight = 0.28 },
+            disk2     = Disk.none{ mass = 0.0 },
+            halo      = Halo.nfwmass{ scaleLength = 16.0, mass = 1.96591393e6 }
+        }
    end
 end
 
@@ -205,6 +309,8 @@ function get_timestep()
     end
 
     if ((evolveTime/t > 150000 or t ~= t) and not timestep_control) then
+        -- We could throw an error here, but instead let it run fast and return a poor likelihood
+        -- This way users won't see errors in their workunit logs
         TooManyTimesteps = 1
         t = evolveTime/4.0
     end
@@ -216,8 +322,11 @@ end
 function get_soft_par()
     --softening parameter only calculated based on dwarf,
     --so if manual bodies is turned on the calculated s.p. may be too large
-    sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d, UseOldSofteningLength)
-
+    if (UseOldSofteningLength == 1) then
+        sp = calculateEps2(totalBodies, rscale_l, rscale_d, mass_l, mass_d)
+    else
+        sp = calculateEps2Dwarf(comp1, totalLightBodies)
+    end
     if ((manual_bodies or use_max_soft_par) and (sp > max_soft_par^2)) then --dealing with softening parameter squared
         print("Using maximum softening parameter value of " .. tostring(max_soft_par) .. " kpc")
         return max_soft_par^2
@@ -232,7 +341,7 @@ function makeContext()
       timeEvolve  = evolveTime,
       timeBack    = revOrbTime,
       timestep    = get_timestep(),
-      eps2        = 1e-4,
+      eps2        = get_soft_par(), 
       b           = orbit_parameter_b,
       r           = orbit_parameter_r,
       vx          = orbit_parameter_vx,
@@ -252,6 +361,7 @@ function makeContext()
       useVlos       = use_vlos_comp,
       useDist       = use_avg_dist,
       usePropMot    = use_pm_comp,
+      useMomentum   = use_momentum,
       Nstep_control = timestep_control,
       Ntsteps       = Ntime_steps,
       BetaSigma     = SigmaCutoff,
@@ -271,8 +381,8 @@ function makeContext()
       InitialOutput = generateInitialOutput,
       theta         = 1.0,
       LMC           = LMC_body,
-      LMCmass       = LMC_Mass,
       LMCfunction   = LMC_function,
+      LMCmass       = LMC_Mass,
       LMCscale      = LMC_scaleRadius,
       LMCscale2     = LMC_cutoff,
       LMCDynaFric   = LMC_DynamicalFriction,
@@ -287,7 +397,9 @@ function makeBodies(ctx, potential)
   local firstModel
   local finalPosition, finalVelocity, LMCfinalPosition, LMCfinalVelocity
     if TooManyTimesteps == 1 then
+        -- Setting bodies to 1 ensures worst case likelihood
         totalBodies = 1
+        totalLightBodies = 1
     end
 
     if(run_null_potential == true and manual_bodies == true) then
@@ -302,10 +414,10 @@ function makeBodies(ctx, potential)
 	            potential   = potential,
 	            position    = lbrToCartesian(ctx, Vector.create(orbit_parameter_l, orbit_parameter_b, orbit_parameter_r)),
 	            velocity    = Vector.create(orbit_parameter_vx, orbit_parameter_vy, orbit_parameter_vz),
-	            LMCposition = Vector.create(-1.1, -41.1, -27.9),
-	            LMCvelocity = Vector.create(-57, -226, 221), 
+	            LMCposition = Vector.create(-0.52, -40.8, -26.5),
+	            LMCvelocity = Vector.create(-58.2, -231, 226),
+		            LMCfunction = LMC_function,
                     LMCmass     = LMC_Mass,
-		            LMCfuction  = LMC_function,
                     LMCscale    = LMC_scaleRadius,
 		            LMCscale2   = LMC_cutoff,
                     LMCDynaFric = LMC_DynamicalFriction,
@@ -339,12 +451,8 @@ function makeBodies(ctx, potential)
         print('Printing reverse orbit')
     end
 
+    if(ModelComponents == 2) then         
 
-    if(ModelComponents == 2) then 
-        -- Create components
-        local comp1 = Dwarf.plummer{mass = mass_l, scaleLength = rscale_l} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        local comp2 = Dwarf.plummer{mass = mass_d, scaleLength = rscale_d} -- Dwarf Options: plummer, nfw, general_hernquist, cored
-        
         firstModel = predefinedModels.mixeddwarf{
             nbody         = totalBodies,
             nbody_baryon  = totalLightBodies,
@@ -356,21 +464,15 @@ function makeBodies(ctx, potential)
             ignore        = true
         }
         
-        -- Store components in the model's table (needed for stability test)
-        firstModel.components = {
-            comp1 = comp1,
-            comp2 = comp2,
-        }
-        
     elseif(ModelComponents == 1) then
-        firstModel = predefinedModels.plummer{  -- Dwarf Options: plummer, nfw, hernq, isotropic
+        firstModel = predefinedModels.plummer{ 
             nbody       = totalBodies,
-            prng        = prng,
-            position    = finalPosition,
-            velocity    = finalVelocity,
             mass        = mass_l,
             scaleRadius = rscale_l,
-            ignore      = false
+            position    = finalPosition,
+            velocity    = finalVelocity,
+            ignore      = false,
+            prng        = prng
         }
   
     end
@@ -408,66 +510,18 @@ function makeHistogram()
      
      betaStart = bta_lower_range,
      betaEnd   = bta_upper_range,
-     betaBins  = bta_bins
+     betaBins  = bta_bins,
+
+     -- Optional params
+     L = {0.0, 0.0, 0.0}, --If any L components are nonzero, will use this L and LErr for momentum likelihood
+     LErr = {0.0, 0.0, 0.0}, --This will overwrite any momentum values passed in through histogram. Input these as lua tables
+
+     nRange = 0, --If non-zero, will use EMDRange values below. Overwrites values given in input histogram
+     EMDRange = {} --Make sure this has an even number of elements and matches nRange. Input as a lua table
 }
 end
 
 
-arg = { ... } -- -- TAKING USER INPUT
-assert((#arg == 6 or #arg == 7 or #arg == 12 or #arg == 13), "Expects either 6, 7, 12, or 13 arguments, and optional manual body list")
-assert(argSeed ~= nil, "Expected seed") -- STILL EXPECTING SEED AS INPUT FOR THE FUTURE
-argSeed = 34086709 -- -- SETTING SEED TO FIXED VALUE
---argSeed = 34086710 -- -- SETTING SEED TO FIXED VALUE
-prng = DSFMT.create(argSeed)
-
--- -- -- -- -- -- -- -- -- ROUNDING USER INPUT -- -- -- -- -- -- -- --
-function round(num, places)
-  local mult = 10.0^(places)
-  return floor(num * mult + 0.5) / mult
-end
-
--- -- -- -- -- -- ROUNDING TO AVOID DIFFERENT COMPUTER TERMINAL PRECISION -- -- -- -- -- --
-dec = 9.0
-evolveTime       = round( tonumber(arg[1]), dec )    -- Forward Time (Gyrs)
-time_ratio       = round( tonumber(arg[2]), dec )    -- Forward Time / Backward Time
-rscale_l         = round( tonumber(arg[3]), dec )    -- Baryonic Radius (kpc)
-light_r_ratio    = round( tonumber(arg[4]), dec )    -- Baryonic Radius / (Baryonic Radius + Dark Matter Radius)
-mass_l           = round( tonumber(arg[5]), dec )    -- Baryonic Mass (Structure Mass Units)
-light_mass_ratio = round( tonumber(arg[6]), dec )    -- Baryonic Mass / (Baryonic Mass + Dark Matter Mass)
-if (#arg >= 7) then
-    if (#arg >= 12) then
-    orbit_parameter_l   = round( tonumber(arg[7]), dec )
-    orbit_parameter_b   = round( tonumber(arg[8]), dec )
-    orbit_parameter_r   = round( tonumber(arg[9]), dec )
-    orbit_parameter_vx  = round( tonumber(arg[10]), dec )
-    orbit_parameter_vy  = round( tonumber(arg[11]), dec )
-    orbit_parameter_vz  = round( tonumber(arg[12]), dec )
-    if (#arg >= 13) then
-        LMC_Mass = round( tonumber(arg[13]), dec )
-    else
-        LMC_Mass = preset_LMC_Mass
-        end
-        manual_body_file = arg[15]
-    else
-        orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    LMC_Mass = round( tonumber(arg[7]), dec )
-    manual_body_file = arg[7] -- File with Individual Particles (.out file)
-    end
-else
-    LMC_Mass = preset_LMC_Mass
-    orbit_parameter_l   = preset_orbit_parameter_l
-    orbit_parameter_b   = preset_orbit_parameter_b
-    orbit_parameter_r   = preset_orbit_parameter_r
-    orbit_parameter_vx  = preset_orbit_parameter_vx
-    orbit_parameter_vy  = preset_orbit_parameter_vy
-    orbit_parameter_vz  = preset_orbit_parameter_vz
-    manual_body_file = arg[8]
-end
 
 -- -- -- -- -- -- -- -- -- DWARF PARAMETERS   -- -- -- -- -- -- -- --
 revOrbTime = evolveTime / time_ratio
@@ -479,17 +533,6 @@ else
 end
 
 
-if(ModelComponents == 1) then
-   dwarfMass = mass_l
-   rscale_t  = rscale_l
-   rscale_d  = 1.0
-   mass_d    = 0.0
-else
-   dwarfMass = mass_l / light_mass_ratio
-   rscale_t  = rscale_l / light_r_ratio
-   rscale_d  = rscale_t *  (1.0 - light_r_ratio)
-   mass_d    = dwarfMass * (1.0 - light_mass_ratio)
-end
    
 
 if(manual_bodies and manual_body_file == nil) then 

--- a/nbody/tests/mixeddwarf_test.c
+++ b/nbody/tests/mixeddwarf_test.c
@@ -153,7 +153,7 @@ static real get_sampling_bound_for_component(const Dwarf* comp, const Dwarf* oth
     
     if (comp->type == NFW || comp->type == Cored) {
 		if (comp->rcut != 0.0) {
-			return comp->rcut + 15.0 * comp->rdecay;
+			return comp->rcut + 10.0 * comp->rdecay;
 		}
 		return 5.0 * comp->r200;
 	}
@@ -855,6 +855,8 @@ int main() {
 	"plummer_hernquist.lua",
 	"plummer_nfw.lua",
 	"plummer_cored.lua",
+	"plummer_cutoff_cored.lua",
+	"plummer_cutoff_nfw.lua",
     };
 
     // Number of models to test

--- a/nbody/tests/mixeddwarf_test.c
+++ b/nbody/tests/mixeddwarf_test.c
@@ -149,6 +149,17 @@ static real rice_rule(const real nbodies) {
     return (int)(2.0 * mw_pow(nbodies, 1.0/3.0));
 }
 
+static real get_sampling_bound_for_component(const Dwarf* comp, const Dwarf* other_comp) {
+    
+    if (comp->type == NFW || comp->type == Cored) {
+		if (comp->rcut != 0.0) {
+			return comp->rcut + 15.0 * comp->rdecay;
+		}
+		return 5.0 * comp->r200;
+	}
+	return 5.0 * comp->scaleLength;
+}
+
 /* Function for the stability test for a given dwarf potential type */
 int test_stability(TestContext* tctx) {
     int failed = 0;
@@ -160,11 +171,11 @@ int test_stability(TestContext* tctx) {
     // Calculate the mass per particle for each component
     tctx->mass_per_particle_baryon = tctx->comp1->mass / tctx->nbody_baryon;
     tctx->mass_per_particle_dark = tctx->comp2->mass / tctx->nbody_dark;
-    // Max radius range for calculation is either 4 times the scale length for plummer and general hernquist or 4 times the r200 for cored and nfw which is the radius bound
-    real baryon_range_limit = (tctx->comp1->type == NFW || tctx->comp1->type == Cored) ? 4.0 * tctx->comp1->r200 : 4.0 * tctx->comp1->scaleLength;
+    // Set bounds for calulating KL divergence
+    real baryon_range_limit = 0.8 * get_sampling_bound_for_component(tctx->comp1, tctx->comp2);
     printf("Baryon range limit: %f\n", baryon_range_limit);
     fflush(stdout);
-    real dark_range_limit = (tctx->comp2->type == NFW || tctx->comp2->type == Cored) ? 4.0 * tctx->comp2->r200 : 4.0 * tctx->comp2->scaleLength;
+    real dark_range_limit = 0.8 * get_sampling_bound_for_component(tctx->comp2, tctx->comp1);
     printf("Dark matter range limit: %f\n", dark_range_limit);
     fflush(stdout);
     // Calculate the bin width for each component

--- a/nbody/tests/test_env_util.c
+++ b/nbody/tests/test_env_util.c
@@ -373,36 +373,53 @@ int read_lua_parameters(const char* input_lua_file, const char** dwarf_params, r
         return 1;
     }
 
-    // Get the components from the model's table
-    lua_getfield(L, -1, "components");
-    if (!lua_istable(L, -1)) {
-        fprintf(stderr, "Error: components table not found in model\n");
-        fflush(stdout);
-        lua_close(L);
-        return 1;
+    /*
+     * Support both legacy and current Lua schemas:
+     * 1) legacy: makeBodies() returns model.components.comp1/comp2
+     * 2) current: comp1/comp2 are script globals used by makeBodies()
+     */
+    *comp1 = NULL;
+    *comp2 = NULL;
+
+    if (lua_istable(L, -1)) {
+        lua_getfield(L, -1, "components");
+        if (lua_istable(L, -1)) {
+            lua_getfield(L, -1, "comp1");
+            if (lua_isuserdata(L, -1)) {
+                *comp1 = (Dwarf*)lua_touserdata(L, -1);
+            }
+            lua_pop(L, 1);
+
+            lua_getfield(L, -1, "comp2");
+            if (lua_isuserdata(L, -1)) {
+                *comp2 = (Dwarf*)lua_touserdata(L, -1);
+            }
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1); // pop components (table or nil)
     }
 
-    // Get comp1
-    lua_getfield(L, -1, "comp1");
-    if (!lua_isuserdata(L, -1)) {
-        fprintf(stderr, "Error: comp1 is not a userdata in Lua model\n");
-        fflush(stdout);
-        lua_close(L);
-        return 1;
-    }
-    *comp1 = (Dwarf*)lua_touserdata(L, -1);
-    lua_pop(L, 1);
+    if (!*comp1 || !*comp2) {
+        lua_getglobal(L, "comp1");
+        if (!lua_isuserdata(L, -1)) {
+            fprintf(stderr, "Error: comp1 is not a userdata in Lua model\n");
+            fflush(stdout);
+            lua_close(L);
+            return 1;
+        }
+        *comp1 = (Dwarf*)lua_touserdata(L, -1);
+        lua_pop(L, 1);
 
-    // Get comp2
-    lua_getfield(L, -1, "comp2");
-    if (!lua_isuserdata(L, -1)) {
-        fprintf(stderr, "Error: comp2 is not a userdata in Lua model\n");
-        fflush(stdout);
-        lua_close(L);
-        return 1;
+        lua_getglobal(L, "comp2");
+        if (!lua_isuserdata(L, -1)) {
+            fprintf(stderr, "Error: comp2 is not a userdata in Lua model\n");
+            fflush(stdout);
+            lua_close(L);
+            return 1;
+        }
+        *comp2 = (Dwarf*)lua_touserdata(L, -1);
+        lua_pop(L, 1);
     }
-    *comp2 = (Dwarf*)lua_touserdata(L, -1);
-    lua_pop(L, 1);
 
     // Validate the components
     if (!*comp1 || !*comp2) {

--- a/run_nbody.sh
+++ b/run_nbody.sh
@@ -19,8 +19,8 @@ then
     -f $PathToMilkyWayAtHomeClientDirectory/nbody/sample_workunits/for_developers.lua \
     -o $PathToMilkyWayAtHomeClientDirectory/output/output.out \
     -z $PathToMilkyWayAtHomeClientDirectory/output/output.hist \
-    -n 64 -w 1 -P -e 54231651 \
-    -i 4.0 1.0 0.2 0.054054 4.5 0.000136345 \
+    -n 8 -w 1 -P -e 54231651 \
+    -i 4.0 1.0 0.2 0.2 12.0 0.2 \
     
 fi
 

--- a/run_nbody.sh
+++ b/run_nbody.sh
@@ -19,8 +19,8 @@ then
     -f $PathToMilkyWayAtHomeClientDirectory/nbody/sample_workunits/for_developers.lua \
     -o $PathToMilkyWayAtHomeClientDirectory/output/output.out \
     -z $PathToMilkyWayAtHomeClientDirectory/output/output.hist \
-    -n 8 -w 1 -P -e 54231651 \
-    -i 4.0 1.0 0.2 0.2 12.0 0.2 \
+    -n 64 -w 1 -P -e 54231651 \
+    -i 4.0 1.0 0.2 0.054054 4.5 0.000136345 \
     
 fi
 


### PR DESCRIPTION
## Summary
This branch adds optional radial cutoff  to `NFW` and `Cored` dwarf profiles used by mixeddwarf generation, fixes the gamma function, adds the error function, updates output/parser for LMC header and syncs tests with the current Lua parameters file. 

## What changed
- Added optional `rcut` input for `Dwarf.nfw{...}` and `Dwarf.cored{...}` (default `rcut = 0.0`, preserving existing behavior when unset).
- Extended dwarf model state with cutoff-related precomputed constants (`rdecay`, `pcut`, `delta`, matching mass/potential continuity terms).
- Updated NFW/Cored density, potential, and mass recalculation paths to support a decaying outer cutoff profile.
- Switched mixeddwarf sampling bounds for cutoff profiles to `rcut + 15 * rdecay` and recalculated component masses accordingly.
- Reworked gamma/incomplete-gamma helper implementation in `nbody_mass.c` and exposed explicit upper/lower incomplete gamma + erf/erfc helpers used by cutoff equations.
- Added `hasLMC` plus LMC position/velocity header support in output parsing structures and I/O header writing.
- Updated test utilities to handle both legacy and current Lua component schemas (`model.components.comp1/comp2` and global `comp1/comp2`).
- Updated mixeddwarf stability test bounds.
- Refreshed test model Lua files under `nbody/tests/mixeddwarf_models/` and updated `for_developers.lua` comments/default potential block accordingly.
- Included a small math macro fix in `milkyway_math_double.h` (`mw_acospi` extra parenthesis).


