### PR TITLE
[NFC] incompatible function pointer types on clang

### DIFF
--- a/nbody/include/nbody_king_model.h
+++ b/nbody/include/nbody_king_model.h
@@ -8,10 +8,10 @@
 #include "nbody_potential_types.h"
 
 real kingDimlessRho(real W, real W0);
-real kingDimless2ndDeriv(real R, real W, real dWdR, Dwarf *model);
-real kingDimlessMass(real R, Dwarf* model, Dwarf* unusedModel, real unusedEnergy, mwbool unusedIsDark);
+real kingDimless2ndDeriv(real R, real W, real dWdR, const Dwarf *model);
+real kingDimlessMass(real R, const Dwarf* model, const Dwarf* unusedModel, real unusedEnergy, mwbool unusedIsDark);
 real kingDensityFromPsi(real psi, real sig, real rho1);
-real kingRelPot2ndDeriv(real r, real psi, real dPsidr, Dwarf *model);
+real kingRelPot2ndDeriv(real r, real psi, real dPsidr, const Dwarf *model);
 
 
 #endif

--- a/nbody/include/nbody_math_funcs.h
+++ b/nbody/include/nbody_math_funcs.h
@@ -5,8 +5,8 @@
 #include "nbody_types.h"
 #include "nbody_potential_types.h"
 
-typedef real (*ODE2ndDeriv)(real, real, real, Dwarf *params);
-real ODE2ndOrderSolver(real xEval, int stepsPerx, real yInit, real yPrimeInit, ODE2ndDeriv f, Dwarf* params, int returnXWhen0);
+typedef real (*ODE2ndDeriv)(real, real, real, const Dwarf *params);
+real ODE2ndOrderSolver(real xEval, int stepsPerx, real yInit, real yPrimeInit, ODE2ndDeriv f, const Dwarf* params, int returnXWhen0);
 
 real GammaFunc(const real z);
 

--- a/nbody/src/nbody_king_model.c
+++ b/nbody/src/nbody_king_model.c
@@ -15,7 +15,7 @@ real kingDimlessRho(real W, real W0) {
 }
 
 // King model dimensionless Poisson equation, evaluated for 2nd derivative term
-real kingDimless2ndDeriv(real R, real W, real dWdR, Dwarf *model) {
+real kingDimless2ndDeriv(real R, real W, real dWdR, const Dwarf *model) {
     real W0 = model->W0; 
     real dimlessRho = kingDimlessRho(W, W0);
 
@@ -24,7 +24,7 @@ real kingDimless2ndDeriv(real R, real W, real dWdR, Dwarf *model) {
 
 // This function is formatted in such a way that gauss_quad() will accept it, the integrand for mu parameter
 // parameters are radius, Dwarf (used), Dwarf (unused), energy (unused), isDark (unused)
-real kingDimlessMass(real R, Dwarf* model, Dwarf* unusedModel, real unusedEnergy, mwbool unusedIsDark) {
+real kingDimlessMass(real R, const Dwarf* model, const Dwarf* unusedModel, real unusedEnergy, mwbool unusedIsDark) {
     real W_R = ODE2ndOrderSolver(R, 1000, model->W0, 0.0, kingDimless2ndDeriv, model, 0);
     return kingDimlessRho(W_R, model->W0) * 4.0 * M_PI * R * R;
 }
@@ -36,7 +36,7 @@ real kingDensityFromPsi(real psi, real sig, real rho1) {
 }
 
 // Equation 4.112 from Binney & Tremaine 2nd ed.
-real kingRelPot2ndDeriv(real r, real psi, real dPsidr, Dwarf *model) {
+real kingRelPot2ndDeriv(real r, real psi, real dPsidr, const Dwarf *model) {
     real rho1 = model->rho1;
     real sigma = model->sigma;
     real rhs = -4.0*M_PI*kingDensityFromPsi(psi, sigma, rho1);

--- a/nbody/src/nbody_math_funcs.c
+++ b/nbody/src/nbody_math_funcs.c
@@ -6,7 +6,7 @@
 // Generic function that numerically solves 2nd order ODEs of the form y'' = f(x, y(x), y'(x)), where y' is dy/dx
 // Uses 4th order Runge-Kutta numerical method, function input is of the form of ODE2ndDeriv
 // The last parameter returnXWhen0 is a special case boolean where the function will instead return the x value where the otherwise positive y(x) function hits zero/negative
-real ODE2ndOrderSolver(real xEval, int stepsPerx, real yInit, real yPrimeInit, ODE2ndDeriv f, Dwarf* params, int returnXWhen0) {
+real ODE2ndOrderSolver(real xEval, int stepsPerx, real yInit, real yPrimeInit, ODE2ndDeriv f, const Dwarf* params, int returnXWhen0) {
     real nSteps = floor(stepsPerx * xEval);
     real stepRes = stepsPerx*xEval - nSteps;
     real deltax = xEval/nSteps;


### PR DESCRIPTION
fixes
nbody_mixeddwarf.c:799:34: error: incompatible function pointer types passing 'real (real, Dwarf *, Dwarf *, real, mwbool)' (aka 'double (double, Dwarf *, Dwarf *, double, char)') to parameter of type 'real (*)(real, const Dwarf *, const Dwarf *, real, mwbool)' (aka 'double (*)(double, const Dwarf *, const Dwarf *, double, char)') [-Wincompatible-function-pointer-types]
  799 |             real mu = gauss_quad(kingDimlessMass, 0.00001, Rt, comp, comp, 0.0, FALSE);
